### PR TITLE
[SECURITY] Updated to latest ElasticSearch 7.16.1

### DIFF
--- a/.ddev/docker-compose.elasticsearch.yaml
+++ b/.ddev/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:7.11.2
+    image: elasticsearch:7.16.1
 
     ports:
       - "9200"


### PR DESCRIPTION
To avoid potential security risks the ElasticSearch is updated to latest
release 7.16.1 to match the version for the production environment.

This updates contains fixes for the Log4j Security Issues reported
https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.1.html