### PR TITLE
Add custom word_delimiter filter

### DIFF
--- a/config/Elasticorn/Elasticorn.yaml
+++ b/config/Elasticorn/Elasticorn.yaml
@@ -1,2 +1,0 @@
-languages:
-  - english

--- a/config/Elasticorn/docsearch/IndexConfiguration.yaml
+++ b/config/Elasticorn/docsearch/IndexConfiguration.yaml
@@ -5,10 +5,16 @@ analysis:
     typo3_stemmer:
       type: stemmer
       language: minimal_english
+    typo3_filter:
+       type: word_delimiter_graph
+       preserve_original: true
   analyzer:
     typo3_analyzer:
+      type: custom
+      tokenizer: whitespace
       filter:
-      - lowercase
-      - asciifolding
-      - typo3_stemmer
-      tokenizer: standard
+        - lowercase
+        - asciifolding
+        - typo3_filter
+        - typo3_stemmer
+

--- a/config/Elasticorn/docsearch/Mapping.yaml
+++ b/config/Elasticorn/docsearch/Mapping.yaml
@@ -1,22 +1,33 @@
 snippet_id:
   type: keyword
 manual_title:
-  type: keyword
+  type: text
+  analyzer: typo3_analyzer
+  fields:
+    raw:
+     type: keyword
 manual_type:
   type: keyword
 manual_version:
   type: keyword
 manual_language:
   type: keyword
+manual_slug:
+  type: keyword
+fragment:
+  type: keyword
 page_title:
   type: text
+  analyzer: typo3_analyzer
 rootline:
   type: keyword
 relative_url:
   type: keyword
 snippet_title:
   type: text
+  analyzer: typo3_analyzer
 snippet_content:
   type: text
+  analyzer: typo3_analyzer
 content_hash:
   type: keyword

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -95,7 +95,7 @@ class ElasticRepository
                     'must' => [
                         [
                             'term' => [
-                                'manual_title' => $manual->getTitle(),
+                                'manual_title.raw' => $manual->getTitle(),
                             ],
                         ],
                         [
@@ -190,7 +190,12 @@ EOD;
                                 [
                                     'query_string' => [
                                         'query' => $searchTerms,
-                                        'fields' => ['page_title^10', 'snippet_title^20', 'snippet_content']
+                                        'fields' => [
+                                            'page_title^10',
+                                            'snippet_title^20',
+                                            'snippet_content',
+                                            'manual_title'
+                                        ]
                                     ],
                                 ],
                             ],
@@ -295,7 +300,7 @@ EOD;
         $elasticaQuery->addAggregation($catAggregation);
 
         $trackerAggregation = new Terms('Document');
-        $trackerAggregation->setField('manual_title');
+        $trackerAggregation->setField('manual_title.raw');
         $catAggregation->addAggregation($trackerAggregation);
 
 //        $status = new Terms('Status');


### PR DESCRIPTION
This should allow splitting text by e.g. colon or slash, and searching parts of the word.

Fixes: https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/31
https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-word-delimiter-tokenfilter.html


Add custom filter and analyzer
Add missing fields to mapping
Remove language configuration as it was conflicting with
custom analyzer config see
TYPO3GmbH/elasticorn#21
Allow searching by extension key (also by fragment
- analyze the extension key)