### PR TITLE
#46 Fix indexing changelog files from cms-core extension

### DIFF
--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -58,7 +58,7 @@ class Manual
             ->in($this->getAbsolutePath())
             ->name('*.html')
             ->notName(['search.html', 'genindex.html', 'Targets.html', 'Quicklinks.html'])
-            ->notPath(['_buildinfo', '_static', '_images', '_sources', 'singlehtml', 'Sitemap']);
+            ->notPath(['_buildinfo', '_images', '_panels_static', '_sources', '_static', 'singlehtml', 'Sitemap']);
 
         if ($this->getTitle() === 'typo3/cms-core') {
             $finder->notPath('Changelog');


### PR DESCRIPTION
The indexing script was previously validating only in the main package directory for the presence of an `objects.inv.json` file. Only directories containing this file were scanned and indexed. However, some packages like `cms-core` only have an `objects.inv` file, not `objects.inv.json`.

With this change, the existence of either `objects.inv` or `objects.inv.json` is checked to determine if a directory should be indexed.

Additionally, the list of excluded subfolders has been expanded to include `_panels_static`.