### PR TITLE
#35 Boost on extension key direct match

### DIFF
--- a/config/Elasticorn/docsearch/Mapping.yaml
+++ b/config/Elasticorn/docsearch/Mapping.yaml
@@ -14,6 +14,8 @@ manual_language:
   type: keyword
 manual_slug:
   type: keyword
+manual_keywords:
+  type: keyword
 fragment:
   type: keyword
 page_title:

--- a/src/Config/ManualType.php
+++ b/src/Config/ManualType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+enum ManualType: string
+{
+    case SystemExtension = 'System extension';
+    case CommunityExtension = 'Community extension';
+    case Typo3Manual = 'TYPO3 manual';
+    case CoreChangelog = 'Core changelog';
+    case DocsHomePage = 'Docs Home Page';
+
+    public function getKey(): string
+    {
+        return match ($this) {
+            self::SystemExtension => 'c',
+            self::CommunityExtension => 'p',
+            self::Typo3Manual => 'm',
+            self::CoreChangelog => 'changelog',
+            self::DocsHomePage => 'h',
+        };
+    }
+
+    public static function getMap(): array
+    {
+        return [
+            'c' => self::SystemExtension->value,
+            'p' => self::CommunityExtension->value,
+            'm' => self::Typo3Manual->value,
+            'changelog' => self::CoreChangelog->value,
+            'h' => self::DocsHomePage->value,
+        ];
+    }
+}

--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -2,6 +2,7 @@
 
 namespace App\Dto;
 
+use App\Config\ManualType;
 use Symfony\Component\Finder\Finder;
 
 class Manual
@@ -12,7 +13,8 @@ class Manual
         private readonly string $type,
         private readonly string $version,
         private readonly string $language,
-        private readonly string $slug
+        private readonly string $slug,
+        private readonly array $keywords
     ) {
     }
 
@@ -31,22 +33,21 @@ class Manual
             [$type, $vendor, $name, $version, $language] = $values;
         }
 
-        $map = [
-            'c' => 'System extension',
-            'p' => 'Community extension',
-            'm' => 'TYPO3 manual',
-            'changelog' => 'Core changelog',
-            'h' => 'Docs Home Page',
-        ];
+        $map = ManualType::getMap();
         $type = $map[$type] ?? $type;
 
+        $keywords = [];
+        if ($type === ManualType::SystemExtension->value || $type === ManualType::CommunityExtension->value) {
+            $keywords[] = $name;
+        }
         return new Manual(
             $folder,
             implode('/', [$vendor, $name]),
             $type,
             $version,
             $language,
-            implode('/', $values)
+            implode('/', $values),
+            $keywords
         );
     }
 
@@ -123,5 +124,10 @@ class Manual
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function getKeywords(): array
+    {
+        return $this->keywords;
     }
 }

--- a/src/Service/ImportManualHTMLService.php
+++ b/src/Service/ImportManualHTMLService.php
@@ -51,6 +51,7 @@ class ImportManualHTMLService
             $section['manual_version'] = $manual->getVersion();
             $section['manual_language'] = $manual->getLanguage();
             $section['manual_slug'] = $manual->getSlug();
+            $section['manual_keywords'] = $manual->getKeywords();
             $section['relative_url'] = $file->getRelativePathname();
             $section['content_hash'] = md5($section['snippet_title'] . $section['snippet_content']);
 

--- a/tests/Unit/Config/ManualTypeTest.php
+++ b/tests/Unit/Config/ManualTypeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Config\ManualType;
+use PHPUnit\Framework\TestCase;
+
+final class ManualTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getKeyForSystemExtension(): void
+    {
+        $this->assertEquals('c', ManualType::SystemExtension->getKey());
+    }
+
+    /**
+     * @test
+     */
+    public function getKeyForCommunityExtension(): void
+    {
+        $this->assertEquals('p', ManualType::CommunityExtension->getKey());
+    }
+
+    /**
+     * @test
+     */
+    public function getKeyForTypo3Manual(): void
+    {
+        $this->assertEquals('m', ManualType::Typo3Manual->getKey());
+    }
+
+    /**
+     * @test
+     */
+    public function getKeyForCoreChangelog(): void
+    {
+        $this->assertEquals('changelog', ManualType::CoreChangelog->getKey());
+    }
+
+    /**
+     * @test
+     */
+    public function getKeyForDocsHomePage(): void
+    {
+        $this->assertEquals('h', ManualType::DocsHomePage->getKey());
+    }
+
+    public function testGetMap(): void
+    {
+        $expectedMap = [
+            'c' => ManualType::SystemExtension->value,
+            'p' => ManualType::CommunityExtension->value,
+            'm' => ManualType::Typo3Manual->value,
+            'changelog' => ManualType::CoreChangelog->value,
+            'h' => ManualType::DocsHomePage->value,
+        ];
+
+        $this->assertEquals($expectedMap, ManualType::getMap());
+    }
+}

--- a/tests/Unit/Service/ImportManualHTMLServiceTest.php
+++ b/tests/Unit/Service/ImportManualHTMLServiceTest.php
@@ -54,6 +54,7 @@ class ImportManualHTMLServiceTest extends TestCase
         $manual->getLanguage()->willReturn('en-us');
         $manual->getSlug()->willReturn('slug');
         $manual->getFilesWithSections()->willReturn($finder->reveal());
+        $manual->getKeywords()->willReturn(['typo3', 'cms', 'core']);
         $manualRevealed = $manual->reveal();
 
         $repo = $this->prophesize(ElasticRepository::class);
@@ -102,6 +103,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'manual_version' => 'main',
             'manual_language' => 'en-us',
             'manual_slug' => 'slug',
+            'manual_keywords' => ['typo3', 'cms', 'core'],
             'relative_url' => 'c/typo3/cms-core/main/en-us',
             'content_hash' => '718ab540920b06f925f6ef7a34d6a5c7',
         ])->shouldBeCalledTimes(1);
@@ -114,6 +116,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'manual_version' => 'main',
             'manual_language' => 'en-us',
             'manual_slug' => 'slug',
+            'manual_keywords' => ['typo3', 'cms', 'core'],
             'relative_url' => 'c/typo3/cms-core/main/en-us',
             'content_hash' => 'a248b5d0798e30e7c9389b81b499c5d9',
         ])->shouldBeCalledTimes(1);


### PR DESCRIPTION
This commit adds new `manual_keywords` field to index. It will store most important keywords related to current manual and for now we store there only system or community extension name.

When such keyword matches any word from searched phrase, the whole query will be boosted by formula `matchedKeywords * 10`.

This computation is done through custom script score defined inside the `ElasticRepository`.

Keep in mind that we expect only full word match here, not partial.

It is important to store in the `manual_keywords` only most important keywords as they have big impact on final order.

Resolves issue: #35