### PR TITLE
#14 Aggregate only major versions and render labels for highest versions

### DIFF
--- a/config/Elasticorn/docsearch/Mapping.yaml
+++ b/config/Elasticorn/docsearch/Mapping.yaml
@@ -33,3 +33,5 @@ snippet_content:
   analyzer: typo3_analyzer
 content_hash:
   type: keyword
+major_versions:
+  type: keyword

--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -19,7 +19,7 @@ readonly class SearchDemand
                 $filterMap = [
                     'Document Type' => 'manual_type',
                     'Language' => 'manual_language',
-                    'Version' => 'manual_version',
+                    'Version' => 'major_versions',
                 ];
                 if (!\array_key_exists($filter, $filterMap)) {
                     continue;

--- a/src/Helper/VersionFilter.php
+++ b/src/Helper/VersionFilter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Helper;
+
+class VersionFilter
+{
+    /**
+     * Filters an array of version strings to return only the highest version for each major version.
+     *
+     * This function groups the provided versions by their major version number, then sorts and selects
+     * the highest version within each major version group. It is assumed that the version strings are in
+     * the format 'major.minor' or similar. The function returns an array of the highest versions for
+     * each major version.
+     *
+     * @param array<string> $versions
+     */
+    public static function filterVersions(array $versions): array
+    {
+        $groupedVersions = [];
+        $nonNumericVersions = [];
+
+        foreach ($versions as $version) {
+            if (!is_numeric(str_replace('.', '', $version))) {
+                $nonNumericVersions[] = $version;
+                continue;
+            }
+
+            $majorVersion = explode('.', $version)[0];
+            $groupedVersions[$majorVersion][] = $version;
+        }
+
+        $highestVersions = [];
+
+        foreach ($groupedVersions as $minorVersions) {
+            usort($minorVersions, static function($a, $b) {
+                return version_compare($b, $a);
+            });
+            $highestVersions[] = $minorVersions[0];
+        }
+
+        return array_merge($highestVersions, $nonNumericVersions);
+    }
+}

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -2,6 +2,7 @@
 
 namespace App\Twig;
 
+use App\Helper\VersionFilter;
 use App\Helper\VersionSorter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Twig\Environment;
@@ -23,6 +24,7 @@ class AppExtension extends AbstractExtension
             new TwigFunction('render_single_asset', $this->renderSingleAsset(...)),
             new TwigFunction('aggregationBucket', $this->aggregationBucket(...), ['is_safe' => ['html']]),
             new TwigFunction('sortVersions', VersionSorter::sortVersions(...)),
+            new TwigFunction('filterVersions', VersionFilter::filterVersions(...)),
         ];
     }
 

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -81,7 +81,7 @@
                                 <a class="text-dark" href="https://docs.typo3.org/{{ latestVersionSlug }}/{{ hit.data.relative_url }}#{{ hit.data.fragment }}">{{ hit.data.snippet_title }}</a>
                                 <small class="text-muted text-decoration-none">{{ hit.data.manual_title }}</small>
                                 <span class="badge badge-secondary text-decoration-none">{{ hit.data.manual_type }}</span>
-                                {% for version in sortVersions(hit.data.manual_version, 'desc') %}
+                                {% for version in sortVersions(filterVersions(hit.data.manual_version), 'desc') %}
                                     {% if version != versionInSlug %}
                                         {% set versionBadgeSlug = hit.data.manual_slug|replace({ (versionInSlug): version }) %}
                                     {% else %}

--- a/tests/Unit/Dto/SearchDemandTest.php
+++ b/tests/Unit/Dto/SearchDemandTest.php
@@ -69,7 +69,7 @@ class SearchDemandTest extends TestCase
                 'Document Type' => ['manual' => 'true'],
                 'Invalid Filter' => ['value' => 'true'],
                 'Language' => ['en-us' => 'true', 'de-de' => 'false'],
-                'Version' => ['12.4' => 'true', '11.5' => 'true'],
+                'Version' => ['12' => 'true', '11' => 'true'],
             ]]
         );
 
@@ -78,7 +78,7 @@ class SearchDemandTest extends TestCase
         $this->assertSame([
             'manual_type' => ['manual'],
             'manual_language' => ['en-us'],
-            'manual_version' => ['12.4', '11.5'],
+            'major_versions' => [12, 11],
         ], $searchDemand->getFilters());
     }
 

--- a/tests/Unit/Helper/VersionFilterTest.php
+++ b/tests/Unit/Helper/VersionFilterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Helper;
+
+use App\Helper\VersionFilter;
+use PHPUnit\Framework\TestCase;
+
+class VersionFilterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function emptyArray(): void
+    {
+        self::assertSame([], VersionFilter::filterVersions([]));
+    }
+
+    /**
+     * @test
+     */
+    public function singleVersion(): void
+    {
+        self::assertSame(['12.1'], VersionFilter::filterVersions(['12.1']));
+    }
+
+    /**
+     * @test
+     */
+    public function multipleVersionsOneMajor(): void
+    {
+        $versions = ['12.1', '12.4', '12.2'];
+        $expected = ['12.4'];
+
+        self::assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function multipleVersionsMultipleMajors(): void
+    {
+        $versions = ['12.1', '12.4', '11.3', '11.5', '10.1'];
+        $expected = ['12.4', '11.5', '10.1'];
+
+        self::assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function unorderedVersions(): void
+    {
+        $versions = ['11.3', '12.1', '11.5', '12.4', '10.1'];
+        $expected = ['11.5', '12.4', '10.1'];
+
+        self::assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function versionsWithSameMajorAndMinor(): void
+    {
+        $versions = ['12.0', '12.0', '11.0', '11.1'];
+        $expected = ['12.0', '11.1'];
+
+        self::assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function versionsWithOnlyMajor(): void
+    {
+        $versions = ['12', '12', '11', '10'];
+        $expected = ['12', '11', '10'];
+
+        self::assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function nonNumericVersions(): void
+    {
+        $versions = ['12.1', 'main', '11.2', 'master', '11.3'];
+        $expected = ['12.1', '11.3', 'main', 'master'];
+
+        $this->assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+
+    /**
+     * @test
+     */
+    public function onlyNonNumericVersions(): void
+    {
+        $versions = ['main', 'master'];
+        $expected = ['main', 'master'];
+
+        $this->assertSame($expected, VersionFilter::filterVersions($versions));
+    }
+}


### PR DESCRIPTION
This commit replaces the all versions aggregation by only major versions.

There is also change for the search results list. Before labels for all versions assigned to the snippet were rendered. After the changes only the highest version in given branch will be rendered. For example, if snippet has versions `main`, `12.4`, `12.0`, `11.5`, `11.3`, `11.0`, `9.5`, only labels for `main`,`12.4`, `11.5`, `9.5` will be rendered.

Resolves issue: #14