### PR TITLE
[TASK] Index also documentation from Other manuals and Exceptions

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,10 +6,12 @@ parameters:
                 - ^m/
                 - ^c/
                 - ^p/
+                - ^other/
+                - ^typo3cms/
+    # should be relative paths to the main folders we search in, see DirectoryFinderService
     docsearch.excluded_directories:
-                - other
                 - draft
-                - typo3cms/extensions
+                - extensions
     .container.dumper.inline_class_loader: true
     assets:
         css:

--- a/src/Config/ManualType.php
+++ b/src/Config/ManualType.php
@@ -11,6 +11,7 @@ enum ManualType: string
     case Typo3Manual = 'TYPO3 manual';
     case CoreChangelog = 'Core changelog';
     case DocsHomePage = 'Docs Home Page';
+    case ExceptionReference = 'Exception Reference';
 
     public function getKey(): string
     {
@@ -20,6 +21,7 @@ enum ManualType: string
             self::Typo3Manual => 'm',
             self::CoreChangelog => 'changelog',
             self::DocsHomePage => 'h',
+            self::ExceptionReference => 'typo3cms',
         };
     }
 
@@ -31,6 +33,8 @@ enum ManualType: string
             'm' => self::Typo3Manual->value,
             'changelog' => self::CoreChangelog->value,
             'h' => self::DocsHomePage->value,
+            'other' => self::Typo3Manual->value,
+            'typo3cms' => self::ExceptionReference->value,
         ];
     }
 }

--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -27,6 +27,14 @@ class Manual
             [$_, $vendor, $name, $__, $language, $type, $version] = $values;
             $type = \strtolower($type);
             $name .= '-' . $type;
+        } elseif (count($pathArray) >= 4 && array_slice($pathArray, -4, 1)[0] === ManualType::ExceptionReference->getKey()) {
+            // typo3 exceptions manuals have different structure than other manuals
+            // they are located in /typo3cms/exceptions/ folder, and we also ignore one other
+            // folder inside /typo3cms/ through services.yaml file and the docsearch.excluded_directories parameter
+            $values = array_slice($pathArray, -5, 5);
+            array_shift($values); // remove the Web part from the path
+            [$type, $name, $version, $language] = $values;
+            $vendor = 'typo3';
         } else {
             // e.g. "c/typo3/cms-workspaces/9.5/en-us"
             $values = array_slice($pathArray, -5, 5);


### PR DESCRIPTION
Before this changes we were indexing only documentations from 3 folders:

- ^m/
- ^c/
- ^p/

which were configured through `services.yaml` file and the `docsearch.allowed_paths` setting. 

There are though important documentation files inside `other` and `typo3cms` folders.

This commit updates the allowed and excluded paths for indexing (services.yaml):

```yaml
parameters:
    docsearch.allowed_paths:
                - ^m/
                - ^c/
                - ^p/
                - ^other/
                - ^typo3cms/
    docsearch.excluded_directories:
                - draft
                - extensions
```

and  introduces special handling for importding documentation of exceptions from `typo3cms/exceptions` folder, where the folders structure is shorted,  and has to be handled different way to have proper slugs, paths etc.