### PR TITLE
[TASK] Index only main version from the typo3/cms-core package

### DIFF
--- a/src/Service/DirectoryFinderService.php
+++ b/src/Service/DirectoryFinderService.php
@@ -51,13 +51,23 @@ class DirectoryFinderService
     {
         $self = $this;
         return static function (\SplFileInfo $file) use ($self) {
-            return $self->objectsFileExists($file->getPathname());
+            return $self->objectsFileExists($file->getPathname()) && $self->isNotIgnoredPath($file->getPathname());
         };
     }
 
     private function objectsFileExists(string $path): bool
     {
         return \file_exists($path . '/objects.inv') || \file_exists($path . '/objects.inv.json');
+    }
+
+    /**
+     * For c/typo3/cms-core/* we want to exclude anything other than c/typo3/cms-core/main
+     * Only manuals from `main` versions should be indexed as changelogs (according to the
+     * documentation team's decision)
+     */
+    private function isNotIgnoredPath(string $path): bool
+    {
+        return !str_contains($path, '/c/typo3/cms-core/') || str_contains($path, 'c/typo3/cms-core/main');
     }
 
     /**

--- a/tests/Unit/Service/DirectoryFinderServiceTest.php
+++ b/tests/Unit/Service/DirectoryFinderServiceTest.php
@@ -67,6 +67,71 @@ class DirectoryFinderServiceTest extends TestCase
         self::assertCount(6, $subject->getAllManualDirectories($rootDir->url()));
     }
 
+    /**
+     * @test
+     * @see DirectoryFinderService::isNotIgnoredPath()
+     */
+    public function respectsIgnoredPats(): void
+    {
+        $subject = new DirectoryFinderService(['^m/', '^c/', '^p/'], []);
+
+        $rootDir = vfsStream::setup('_docsFolder', null, [
+            'c' => [
+                'typo3' => [
+                    'cms-core' => [
+                        '10.4' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                        '11.5' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                        'main' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                    ],
+                    'cms-form' => [
+                        '12.4' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                        'main' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'm' => [
+                'typo3' => [
+                    'reference-coreapi' => [
+                        '9.5' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                        'main' => [
+                            'en-us' => [
+                                'objects.inv.json' => ''
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        // since DirectoryFinderService::isNotIgnoredPath() should ignore all versions of typo3/cms-core
+        // except the main version, we should have 5 directories returned
+        self::assertCount(5, $subject->getAllManualDirectories($rootDir->url()));
+    }
+
     public function getAllManualDirectoriesRespectsOnlyDirectoriesWithMetadataFileDataProvider(): array
     {
         return [


### PR DESCRIPTION
Since the `c/typo3/cms-core` contains only changelog manuals, and according to the documentation team only the `main` versions should be indexed, with this commit all other versions from the `typo3/cms-core` will be ignored.

Resolves #74