### PR TITLE
[TASK] Remove the db container on DDEV as it's not needed

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,12 +8,10 @@ router_https_port: "443"
 xdebug_enabled: true
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.3"
-mysql_version: ""
 use_dns_when_possible: true
 composer_version: ""
 web_environment: []
-
+omit_containers: [db]
 
 # This config.yaml was created with ddev version v1.17.0
 # webimage: drud/ddev-webserver:v1.17.0


### PR DESCRIPTION
As far as I know, there is no need for MariaDB on this project. So we can remove the default DDEV db container from the local env.

