### PR TITLE
[TASK] Improve suggestion endpoint to expose slugs and support vendor

### DIFF
--- a/.ddev/nginx/cors.conf
+++ b/.ddev/nginx/cors.conf
@@ -1,0 +1,5 @@
+# Make it easy to test from another DDEV project like render-guides
+add_header Access-Control-Allow-Origin *;
+add_header Access-Control-Allow-Methods *;
+add_header Access-Control-Allow-Headers *;
+add_header Access-Control-Allow-Credentials *;

--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -72,6 +72,10 @@ readonly class SearchDemand
         if ($scope) {
             $filters['manual_slug'] = [$scope];
         }
+        $vendor = trim(htmlspecialchars(strip_tags((string)$request->query->get('vendor'))), '/');
+        if ($vendor) {
+            $filters['manual_vendor'] = [$vendor];
+        }
 
         return new self($query, $scope, max($page, 1), $filters, $areSuggestionsHighlighted);
     }


### PR DESCRIPTION
Improve the suggestion API needed in https://github.com/TYPO3-Documentation/render-guides/pull/851:

- add the package slug to send the user directly to a package Index page
- search with empty query are now allowed if you have a filter - for example listing all documents from a vendor
- when scoping with both a package and a version, the slug points to the requested version :star_struck: 

On the developer side:

- I added a cors configuration in DDEV, allowing to use the API from JavaScript between the two DDEV projects
- No reindexation needed, this can be deployed like this :+1: 