### PR TITLE
[FIX] Add special handling of Changelog scope to use "type" instead of "slug"

### DIFF
--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -2,6 +2,7 @@
 
 namespace App\Dto;
 
+use App\Config\ManualType;
 use Symfony\Component\HttpFoundation\Request;
 
 readonly class SearchDemand
@@ -70,7 +71,13 @@ readonly class SearchDemand
         // scope points to given manual version and language
         $scope = trim(htmlspecialchars(strip_tags((string)$request->query->get('scope'))), '/');
         if ($scope) {
-            $filters['manual_slug'] = [$scope];
+            // special treatment for the Changelog scope because version is "wrong" here
+            // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/89#issuecomment-2696410395
+            if (str_contains($scope, 'c/typo3/cms-core/main/en-us/Changelog') && empty($filters['manual_type'])) {
+                $filters['manual_type'] = ManualType::CoreChangelog->value;
+            } else {
+                $filters['manual_slug'] = [$scope];
+            }
         }
         $vendor = trim(htmlspecialchars(strip_tags((string)$request->query->get('vendor'))), '/');
         if ($vendor) {

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -504,10 +504,6 @@ EOD;
     {
         $searchTerms = Util::escapeTerm($searchDemand->getQuery());
 
-        // 2 LTS + Main
-        $boostedVersions = Typo3VersionMapping::getLtsVersions();
-        $boostedVersions[] = Typo3VersionMapping::Dev;
-
         $query = [
             'query' => [
                 'function_score' => [


### PR DESCRIPTION
Refs: #89 

When using "search current", the current manual slug is used as a filter.

This works fine for documentation but changelog are a bit different.

The goal of this PR is to swap the "current slug" for changelog by a broader "current type" filter, which is more relevant when it come to changelog because it does not restrict by version.

# Before

![image](https://github.com/user-attachments/assets/cd508cf0-0480-43f0-b0c9-44f36b80aecc)


# After

![image](https://github.com/user-attachments/assets/422145e7-e192-4fa0-9fe7-9d0429f1e538)
