### PR TITLE
[TASK] Add "latest" and "all" version facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Important changes made to the project.
 ### Changed
 
 - Improve version handling in search results
+- Add search-time "all" and "latest" versions for aggregations
 
 ## 2024-12-03
 

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -41,6 +41,7 @@ class SearchController extends AbstractController
         return $this->render('search/search.html.twig', [
             'q' => $searchDemand->getQuery(),
             'searchScope' => $searchDemand->getScope(),
+            'searchFilter' => $searchDemand->getCurrentFilters(),
             'filters' => $request->get('filters', []),
             'results' => $this->elasticRepository->findByQuery($searchDemand),
         ]);

--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -64,6 +64,7 @@ readonly class SearchDemand
                 }
             }
         }
+
         $page = (int)$request->query->get('page', '1');
         $query = $request->query->get('q', '');
         $areSuggestionsHighlighted = (bool)$request->query->get('suggest-highlight');
@@ -79,9 +80,15 @@ readonly class SearchDemand
                 $filters['manual_slug'] = [$scope];
             }
         }
+
         $vendor = trim(htmlspecialchars(strip_tags((string)$request->query->get('vendor'))), '/');
         if ($vendor) {
             $filters['manual_vendor'] = [$vendor];
+        }
+
+        // default version is "latest"
+        if (empty($filters['major_versions'])) {
+            $filters['major_versions'] = ['latest'];
         }
 
         return new self($query, $scope, max($page, 1), $filters, $areSuggestionsHighlighted);

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -67,7 +67,7 @@ class AppExtension extends AbstractExtension
         return $assetsConfig[$assetType][$assetLocation] ?? [];
     }
 
-    public function aggregationBucket(string $category, string $index, array $bucket): string
+    public function aggregationBucket(string $category, string $index, array $bucket, array $searchFilter): string
     {
         $category = strtolower($category);
         $label = $bucket['key_as_string'] ?? $bucket['key'];
@@ -75,11 +75,12 @@ class AppExtension extends AbstractExtension
         $key = $bucket['key'];
 
         // check if checkbox has been set
-        if (isset($_GET['filters'][$category][$key]) && $_GET['filters'][$category][$key] === 'true') {
+        if (isset($searchFilter[$category][$key]) && $searchFilter[$category][$key] === 'true') {
             $checked = ' checked';
         } else {
             $checked = '';
         }
+
         return '<div class="form-check">'
             . '<input type="checkbox" class="form-check-input" id="' . $category . '-' . $index . '" name="filters[' . $category . '][' . $key . ']" ' . $checked . ' value="true" onchange="this.form.submit()">'
             . '<label class="form-check-label custom-control-label-hascount" for="' . $category . '-' . $index . '">'

--- a/templates/partial/aggregations.html.twig
+++ b/templates/partial/aggregations.html.twig
@@ -21,7 +21,7 @@
                         <div class="aggregation-body">
                             {% for index, bucket in buckets.buckets %}
                                 {% if bucket.doc_count > 0 %}
-                                    {{ aggregationBucket(title, index, bucket) }}
+                                    {{ aggregationBucket(title, index, bucket, searchFilter) }}
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -105,7 +105,7 @@
                 <div class="wy-menuXX wy-menu-verticalXX" data-spy="affix" role="navigation" aria-label="main navigation">
                     <form action="{{ path('searchresult') }}" method="get" class="form">
                         <input type="hidden" name="q" value="{{ (q is defined) ? q : '' }}">
-                        {% include 'partial/aggregations.html.twig' with {'aggregations': results.aggs, 'query': q} only %}
+                        {% include 'partial/aggregations.html.twig' with {'aggregations': results.aggs, 'query': q, 'searchFilter': searchFilter} only %}
                     </form>
                 </div>
             </div>

--- a/tests/Unit/Dto/SearchDemandTest.php
+++ b/tests/Unit/Dto/SearchDemandTest.php
@@ -29,7 +29,8 @@ class SearchDemandTest extends TestCase
         $this->assertSame(2, $searchDemand->getPage());
         $this->assertSame([
             'manual_type' => ['manual'],
-            'manual_slug' => ['p/vendor/package/main/en-us']
+            'manual_slug' => ['p/vendor/package/main/en-us'],
+            'major_versions' => ['latest']
         ], $searchDemand->getFilters());
     }
 
@@ -45,7 +46,9 @@ class SearchDemandTest extends TestCase
         $this->assertSame('', $searchDemand->getQuery());
         $this->assertSame('', $searchDemand->getScope());
         $this->assertSame(1, $searchDemand->getPage());
-        $this->assertSame([], $searchDemand->getFilters());
+        $this->assertSame([
+            'major_versions' => ['latest']
+        ], $searchDemand->getFilters());
     }
 
     /**
@@ -57,7 +60,9 @@ class SearchDemandTest extends TestCase
 
         $searchDemand = SearchDemand::createFromRequest($request);
 
-        $this->assertSame([], $searchDemand->getFilters());
+        $this->assertSame([
+            'major_versions' => ['latest']
+        ], $searchDemand->getFilters());
     }
 
     /**
@@ -122,7 +127,9 @@ class SearchDemandTest extends TestCase
 
         $searchDemand = SearchDemand::createFromRequest($request);
 
-        $this->assertSame([], $searchDemand->getFilters());
+        $this->assertSame([
+            'major_versions' => ['latest']
+        ], $searchDemand->getFilters());
     }
 
     /**


### PR DESCRIPTION
Adds "all" and "latest" as major version to be able to filter them via aggregations / facet navigation.

- Those version are always on top even if the doc_count is not high
- The "latest" is selected by default as it was the behavior introduced in #107 
- Also removed usage of `$_GET` in Twig Extension (bad practice)

> [!WARNING]  
> To see the new version filters, a full reindex is needed. Also expect strange results during the reindex as the search query from #107 are changed.

As the version tag "latest" is in the index, when a new major version comes out, a reindex of the full module must be done so that the version N-3 loss it's "latest" tag.

> [!IMPORTANT]  
> When updating `t3docs/typo3-version-handling`, run a full reindex.

---

![image](https://github.com/user-attachments/assets/864d3b6d-de6c-48bc-9a8a-b0fc3b9d7585)