### PR TITLE
[TASK] Only boost the Stable version on search results

### DIFF
--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -589,18 +589,16 @@ EOD;
                         ],
                         [
                             'filter' => [
-                                // query matching LTS versions
-                                'terms' => [
-                                    'manual_version' => array_map(function (Typo3VersionMapping $version) {
-                                        return $version->getVersion();
-                                    }, Typo3VersionMapping::getLtsVersions())
+                                // query matching stable major version
+                                'term' => [
+                                    'manual_version' => Typo3VersionMapping::Stable->getVersion()
                                 ]
                             ],
                             'weight' => 5
                         ],
                         [
                             'filter' => [
-                                // query matching Main
+                                // query matching main
                                 'term' => [
                                     'manual_version' => Typo3VersionMapping::Dev->getVersion()
                                 ]


### PR DESCRIPTION
Refs: #111

## Before

Both LTS versions (12 and 13) were getting a boost

## After

Only Stable (13) is getting a boost