### PR TITLE
[TASK] Improve search pertinency on multi-word + general scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Important changes made to the project.
 
+## 2025-03-17
+
+### Changed
+
+- Improve search pertinence, give more power to multi-words matches, show more fragments
+- Boost only the Stable version
+
 ## 2025-03-03
 
 ### Changed

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -555,17 +555,31 @@ EOD;
                         'bool' => [
                             'must' => [
                                 $searchTerms ? [
-                                    'query_string' => [
+                                    'multi_match' => [
                                         'query' => $searchTerms,
+                                        'type' => 'most_fields',
                                         'fields' => [
                                             'page_title^10',
-                                            'snippet_title^20',
-                                            'snippet_content',
+                                            'snippet_title^10',
+                                            'snippet_content^5',
                                             'manual_title'
                                         ]
                                     ],
                                 ] : ['match_all' => new \stdClass()],
                             ],
+                            // Boost documents with ALL the terms
+                            'should' => [
+                                $searchTerms ? [
+                                    'multi_match' => [
+                                        'query' => $searchTerms,
+                                        'operator' => 'and',
+                                        'fields' => [
+                                            'page_title^5',
+                                            'snippet_content^5',
+                                        ]
+                                    ],
+                                ] : ['match_all' => new \stdClass()],
+                            ]
                         ],
                     ],
                     'functions' => [
@@ -613,8 +627,8 @@ EOD;
             'highlight' => [
                 'fields' => [
                     'snippet_content' => [
-                        'fragment_size' => 400,
-                        'number_of_fragments' => 1
+                        'fragment_size' => 200,
+                        'number_of_fragments' => 2
                     ]
                 ],
                 'encoder' => 'html'

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -84,7 +84,9 @@
                             </h4>
                             <div class="position-relative">
                                 {% if hit.highlights and hit.highlights.snippet_content and hit.highlights.snippet_content[0] %}
-                                    <p class="summary">{{ hit.highlights.snippet_content[0] | raw }}...</p>
+                                    <p class="summary">
+                                        {% for content in hit.highlights.snippet_content %}{{ content | raw }}...{% endfor %}
+                                    </p>
                                 {% else %}
                                     <p class="summary">{{ hit.data.snippet_content|slice(0, 400) }}...</p>
                                 {% endif %}


### PR DESCRIPTION
Refs: #80

Change how searches are done:

- replace query_string by multi_match (query_string is not [recommended for production search boxes](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html))
- tune the fields boost to reduce the gap between title and content
- add a "signal" with operator "and" allowing a greater score for documents matching all the keywords*

Change how searches results are shown:

- it was configured with one 400 chars fragment, changed to two 200 chars fragments to better show matches in contents

Overhaul I feel search results are way better but it's only an opinion :yum: 

# Screenshots

| Before | After |
|--------|--------|
| Temporary File ![image](https://github.com/user-attachments/assets/64dea4d5-2874-42ea-83f0-ee757fe377ec) | Temporary File ![image](https://github.com/user-attachments/assets/6c60bf6a-030c-4174-b5de-178dfdfd73d6) |
| TCA Search ![image](https://github.com/user-attachments/assets/d7feab24-24c9-4069-9cad-57bfd0806771) | TCA Search ![image](https://github.com/user-attachments/assets/3d144596-908c-4269-8579-e468b6cfb179)   | 
| Proxy Settings ![image](https://github.com/user-attachments/assets/850983de-fd8e-4680-a6ac-ae44856ea668) | Proxy Settings ![image](https://github.com/user-attachments/assets/cefc5ba7-efaf-468a-815d-689c6934b9d8) | 

