### PR TITLE
[TASK] Index section keywords to alter search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Important changes made to the project.
 
 - Improve search pertinence, give more power to multi-words matches, show more fragments
 - Boost only the Stable version
+- Added support for `data-keywords` attribute on `<section>` to boost searches
 
 ## 2025-03-03
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 TYPO3 Documentation Search
 ==========================
 
+- Parse HTML rendered documentation to index each `<section>` in Elasticsearch
+- Provide frontend and API for end-user documentation search
+
 Install locally
 ---------------
 

--- a/config/Elasticorn/docsearch/Mapping.yaml
+++ b/config/Elasticorn/docsearch/Mapping.yaml
@@ -59,8 +59,6 @@ option:
     large_suggest:
       type: search_as_you_type
       analyzer: typo3_autocomplete_large
-option_keywords:
-  type: keyword
 fragment:
   type: keyword
 page_title:
@@ -84,3 +82,7 @@ is_core:
   type: boolean
 is_last_versions:
   type: boolean
+# Keyword of the section, added via data-keywords attribute, used to boost search.
+keywords:
+  type: text
+  analyzer: typo3_analyzer

--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -16,7 +16,7 @@ class Manual
         private readonly string $version,
         private readonly string $language,
         private readonly string $slug,
-        private readonly array $keywords,
+        private readonly array $keywords, // Keywords on the Manual level
         private readonly string $vendor = '',
         private readonly bool $isCore = false,
         private readonly bool $isLastVersions = true, // Does this Manual entry lives in the last 2 major versions? (+main)

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -562,7 +562,8 @@ EOD;
                                             'page_title^10',
                                             'snippet_title^10',
                                             'snippet_content^5',
-                                            'manual_title'
+                                            'manual_title',
+                                            'keywords^4'
                                         ]
                                     ],
                                 ] : ['match_all' => new \stdClass()],

--- a/src/Service/ParseDocumentationHTMLService.php
+++ b/src/Service/ParseDocumentationHTMLService.php
@@ -35,9 +35,12 @@ class ParseDocumentationHTMLService
                 $mergedSnippet['fragment'] = $section['fragment'];
                 $mergedSnippet['snippet_title'] = $section['snippet_title'];
                 $mergedSnippet['snippet_content'] = $section['snippet_content'];
+                $mergedSnippet['keywords'] = $section['keywords'] ?? [];
             } else {
                 $mergedSnippet['snippet_content'] .= "\n" . $section['snippet_title'];
                 $mergedSnippet['snippet_content'] .= "\n" . $section['snippet_content'];
+                $mergedSnippet['keywords'] = array_merge($mergedSnippet['keywords'], $section['keywords'] ?? []);
+                $mergedSnippet['keywords'] = array_values(array_unique($mergedSnippet['keywords']));
             }
         }
 
@@ -88,21 +91,14 @@ class ParseDocumentationHTMLService
                 $section->removeChild($foundHeadline['node']);
             } else {
                 $id = $section->getAttribute('data-search-id');
-                $optionKeywords = json_decode($section->getAttribute('data-search-keywords'));
-
                 if ($id === '' || $title === '') {
                     continue;
-                }
-
-                if (!is_array($optionKeywords)) {
-                    $optionKeywords = [$title];
                 }
 
                 $sectionPiece = [
                     'fragment' => $id,
                     'snippet_title' => $title,
                     'option' => $option,
-                    'option_keywords' => $optionKeywords,
                 ];
             }
 
@@ -112,6 +108,13 @@ class ParseDocumentationHTMLService
             $sectionPiece['snippet_content'] = $this->sanitizeString(
                 $section->textContent
             );
+
+            $keywords = $section->getAttribute('data-keywords');
+            if ($keywords) {
+                $sectionPiece['keywords'] = array_map('trim', explode(",", $keywords));
+                $sectionPiece['keywords'] = array_values(array_unique($sectionPiece['keywords']));
+            }
+
             $sectionPieces[] = $sectionPiece;
         }
 

--- a/tests/Unit/Service/Fixtures/ParseDocumentationHTMLServiceTest/ReturnsSectionsFromFile/MarkupWithSubSections.html
+++ b/tests/Unit/Service/Fixtures/ParseDocumentationHTMLServiceTest/ReturnsSectionsFromFile/MarkupWithSubSections.html
@@ -6,10 +6,10 @@
 <article>
 <div itemprop="articleBody">
 <!-- body -->
-<section class="section" id="deprecation-88839-cli-lowlevel-request-handlers">
+<section class="section" id="deprecation-88839-cli-lowlevel-request-handlers" data-keywords="testKeywordTopLevel">
 <h1>Deprecation: #88839 - CLI lowlevel request handlers<a class="headerlink" href="#deprecation-88839-cli-lowlevel-request-handlers" title="Permalink to this headline">¶</a></h1>
 <p>See <a class="reference external" href="https://forge.typo3.org/issues/88839">Issue #88839</a></p>
-<section class="section" id="description">
+<section class="section" id="description" data-keywords="testKeywordSubSection">
 <h2>Description<a class="headerlink" href="#description" title="Permalink to this headline">¶</a></h2>
 <p>The interface <code class="code php docutils literal notranslate"><span class="pre">\TYPO3\CMS\Core\Console\RequestHandlerInterface</span></code>
 and the class <code class="code php docutils literal notranslate"><span class="pre">\TYPO3\CMS\Core\Console\CommandRequestHandler</span></code> have been introduced in TYPO3 v7 to streamline

--- a/tests/Unit/Service/ParseDocumentationHTMLServiceTest.php
+++ b/tests/Unit/Service/ParseDocumentationHTMLServiceTest.php
@@ -515,7 +515,10 @@ elements."
                     [
                         'fragment' => 'deprecation-88839-cli-lowlevel-request-handlers',
                         'snippet_title' => 'Deprecation: #88839 - CLI lowlevel request handlers',
-                        'snippet_content' => 'See Issue #88839'
+                        'snippet_content' => 'See Issue #88839',
+                        'keywords' => [
+                            'testKeywordTopLevel'
+                        ]
                     ],
                     [
                         'fragment' => 'description',
@@ -529,6 +532,9 @@ elements."
                             'a wrapper around Symfony Console. All logic is now located in the Application, and thus, the interface and',
                             'the class have been marked as deprecated.',
                         ]),
+                        'keywords' => [
+                            'testKeywordSubSection'
+                        ],
                     ],
                     [
                         'fragment' => 'impact',
@@ -629,6 +635,10 @@ elements."
                 'Migration',
                 'Switch to a Symfony Command or provide a custom CLI entry point.',
             ]),
+            'keywords' => [
+                'testKeywordTopLevel',
+                'testKeywordSubSection'
+            ],
         ], $result);
     }
 


### PR DESCRIPTION
Refs: #33

Introduce a new way to push some words in the search index.

As described in https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/33#issuecomment-1865845721 ; you can now add a `data-keywords` attribute on documentation `<section>`.

```html
<section class="section" id="typo3-admin-panel" data-keywords="administation, backend">
```

Those keywords are comma separated (whitespaces allowed, no impact).

This can be used:

- as synonym (a page talking about "admin panel" can now match "admin backend")
- as extra keywords for search

The new field is analyzed like the others so plural form, case and stemming are handled.

```yaml
keywords:
  type: text
  analyzer: typo3_analyzer
```

 > [!IMPORTANT]  
> A full remap will be needed for this feature to be visible live