### PR TITLE
Add slot for search input in result page

### DIFF
--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -65,7 +65,7 @@
                         {% include 'partial/base/breadcrumbs.html.twig' %}
                     {% endblock %}
 
-                    <div id="search-results"></div>
+                    <div id="global-search-results"></div>
 
                     <div class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
                         <div itemprop="articleBody">

--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -65,7 +65,7 @@
                         {% include 'partial/base/breadcrumbs.html.twig' %}
                     {% endblock %}
 
-                    <div id="global-search-results"></div>
+                    <div id="global-search-results" class="w-50"></div>
 
                     <div class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
                         <div itemprop="articleBody">

--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -65,6 +65,8 @@
                         {% include 'partial/base/breadcrumbs.html.twig' %}
                     {% endblock %}
 
+                    <div id="search-results"></div>
+
                     <div class="document" itemscope="itemscope" itemtype="http://schema.org/Article" role="main">
                         <div itemprop="articleBody">
                             {% block page_content %}{% endblock %}

--- a/templates/partial/base/page_header.html.twig
+++ b/templates/partial/base/page_header.html.twig
@@ -11,21 +11,14 @@
                 <div class="menu-search-wrapper">
                     <all-documentations-menu></all-documentations-menu>
                     <search role="search">
-                        <form id="rtd-search-form" class="wy-form" action="{{ path('searchresult') }}" method="get">
+                        <form action="{{ path('searchresult') }}" id="global-search-form" method="get">
+                            <div class="sr-only"><label for="globalsearchinput">TYPO3 documentation...</label></div>
                             <div class="input-group mb-3 mt-sm-3">
                                 <select class="form-select search__scope" id="searchscope" name="scope">
                                     <option value="">Search all</option>
-                                    {% if searchScope is defined and searchScope is not empty %}
-                                        <option value="{{ searchScope|striptags|escape }}" selected="selected">Search
-                                            current
-                                        </option>
-                                    {% endif %}
                                 </select>
-                                <input type="text" class="form-control shadow-none" name="q" autocomplete="off"
-                                       placeholder="Search in TYPO3 documentation" id="searchinput"
-                                       value="{% if q is defined %}{{ q }}{% endif %}">
-                                <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span
-                                            class="d-none d-md-inline">Search</span></button>
+                                <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>
                         <div id="global-search-root"></div>

--- a/templates/partial/base/page_header.html.twig
+++ b/templates/partial/base/page_header.html.twig
@@ -1,13 +1,13 @@
 <div class="page-header">
     <div class="page-header-inner">
         <div class="row">
-            <div class="col-md-2 col-lg-4">
+            <div class="col-2 col-lg-4">
                 <a class="logo" href="/" title="TYPO3 Documentation">
                     <img alt="TYPO3 Logo" class="logo-image"
                          height="130" src="https://cdn.typo3.com/typo3documentation/theme/sphinx_typo3_theme/4.5.1/img/typo3-logo.svg" width="484"/>
                 </a>
             </div>
-            <div class="col-md-10 col-lg-8">
+            <div class="col-10 col-lg-8">
                 <div class="menu-search-wrapper">
                     <all-documentations-menu></all-documentations-menu>
                     <search role="search">
@@ -24,7 +24,7 @@
                                 <input type="text" class="form-control shadow-none" name="q" autocomplete="off"
                                        placeholder="Search in TYPO3 documentation" id="searchinput"
                                        value="{% if q is defined %}{{ q }}{% endif %}">
-                                <button class="btn btn-light search__submit" type="submit"><i class="fa fa-search"></i>&nbsp;<span
+                                <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span
                                             class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>


### PR DESCRIPTION
## Issue

https://github.com/TYPO3-Documentation/render-guides/issues/928

## Changes

- Change `pageHeader.html.twig` to apply changes made on https://github.com/TYPO3-Documentation/render-guides/pull/933
- Add slot to allow second search input above results