### PR TITLE
[BUGFIX] Add missing `<header>` around page-topbar & page-header

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,16 +16,16 @@ parameters:
     assets:
         css:
             header:
-                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.27.0/css/theme.css'
+                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.37.1/css/theme.css'
             footer:
         js:
             header:
                 -  'https://cdn.typo3.com/typo3infrastructure/universe/dist/webcomponents-loader.js'
                 - 'https://cdn.typo3.com/typo3infrastructure/universe/dist/typo3-universe.js'
             footer:
-                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.27.0/js/popper.min.js'
-                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.27.0/js/bootstrap.min.js'
-                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.27.0/js/theme.min.js'
+                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.37.1/js/popper.min.js'
+                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.37.1/js/bootstrap.min.js'
+                - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.37.1/js/theme.min.js'
 
 services:
     # default configuration for services in *this* file

--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -43,13 +43,15 @@
 </head>
 <body>
 <div class="page">
-    {% block topbar %}
-        {% include 'partial/base/topbar.html.twig' %}
-    {% endblock %}
+    <header>
+        {% block topbar %}
+            {% include 'partial/base/topbar.html.twig' %}
+        {% endblock %}
 
-    {% block page_header %}
-        {% include 'partial/base/page_header.html.twig' %}
-    {% endblock %}
+        {% block page_header %}
+            {% include 'partial/base/page_header.html.twig' %}
+        {% endblock %}
+    </header>
 
     <div class="page-main">
         <div class="page-main-inner">


### PR DESCRIPTION
This aligns the styling with typical docs.typo3.org pages, where the page-topbar & page-header are inside a sticky `header`-tag.

See:
render-guides/packages/typo3-api/template/components/header.html.twig

https://github.com/TYPO3-Documentation/render-guides/blob/49433a3d3cb8cf3dba30d58d645beac4ea44c29c/packages/typo3-api/template/components/header.html.twig