### PR TITLE
fix(deletion): guard against scalar manual_slug in delete script (educated-guess fix)

### DIFF
--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -201,7 +201,10 @@ if (ctx._source.manual_version.contains(params.manual_version)) {
             ctx._source.manual_version.remove(i);
         }
     }
-    
+
+    if (!(ctx._source.manual_slug instanceof List)) {
+        ctx._source.manual_slug = [ctx._source.manual_slug];
+    }
     for (int i=ctx._source.manual_slug.length-1; i>=0; i--) {
         if (ctx._source.manual_slug[i].contains(params.manual_version)) {
             ctx._source.manual_slug.remove(i);


### PR DESCRIPTION
> ## ⚠️ This is an EDUCATED GUESS, not a verified fix
>
> I do **not** have access to the production Elasticsearch instance to confirm the actual `_source` shape of the affected documents. The diagnosis below is reasoned from the public source code and CI logs, then confirmed end-to-end against a local Elasticsearch 7.17.1 (the same image as `.ddev/docker-compose.elasticsearch.yaml`). Reviewers with shell access to the docs server should still verify the production `_source` shape before merging.

## Problem

The `Update search data` step of [t3docs-ci-deploy / Main Rendering](https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/25623654511/job/75214737747) fails for `typo3/docs-homepage` with `Elastica\Exception\ResponseException: runtime error`. Render itself succeeds — only `docsearch:import` errors out. (See comments for evidence that this has been failing for ~3 weeks.)

## Cause

The Painless script in [`ElasticRepository::getDeleteQueryScript()`](https://github.com/TYPO3-Documentation/t3docs-search-indexer/blob/main/src/Repository/ElasticRepository.php#L195-L228) iterates `ctx._source.manual_slug` as a `List`, but the field can also be stored as a scalar `String` (legacy shape from before the multi-slug migration). Painless then trips on `String.length` (no such property accessor — only `.length()` method) and throws `script_exception`.

The companion script in [`addOrUpdateDocument()`](https://github.com/TYPO3-Documentation/t3docs-search-indexer/blob/main/src/Repository/ElasticRepository.php#L86-L88) already wraps a scalar slug into a list defensively. This PR ports the same one-line guard into the delete-by-query script.

## Diff

```diff
 if (ctx._source.manual_version.contains(params.manual_version)) {
     for (int i=ctx._source.manual_version.length-1; i>=0; i--) {
         if (ctx._source.manual_version[i] == params.manual_version) {
             ctx._source.manual_version.remove(i);
         }
     }
+
+    if (!(ctx._source.manual_slug instanceof List)) {
+        ctx._source.manual_slug = [ctx._source.manual_slug];
+    }
     for (int i=ctx._source.manual_slug.length-1; i>=0; i--) {
         if (ctx._source.manual_slug[i].contains(params.manual_version)) {
             ctx._source.manual_slug.remove(i);
         }
     }
 }
```

**Risk:** zero. If `manual_slug` is already a `List`, the guard is a no-op; if it's a scalar, the script now works instead of throwing.

See comments for: local reproduction with before/after, full ES `caused_by` text (Elastica hides it), failure timeline.