### PR TITLE
[FIX] Make Core Changelog searchable from the changelog landing page

### DIFF
--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -71,11 +71,15 @@ readonly class SearchDemand
         // scope points to given manual version and language
         $scope = trim(htmlspecialchars(strip_tags((string)$request->query->get('scope'))), '/');
         if ($scope) {
-            // Special treatment for the Core Changelog: cms-core is only ever indexed
-            // as changelog (see DirectoryFinderService::isNotIgnoredPath), so any cms-core
-            // scope — including the manual root /c/typo3/cms-core/main/en-us/ used by the
-            // search modal on the changelog landing page — must use the type filter,
-            // not the slug filter.
+            // Special treatment for cms-core scopes: the Core Changelog is
+            // indexed as one CoreChangelog sub-manual per version under
+            // c/typo3/cms-core/main/en-us/Changelog/<version>/. The search
+            // modal on the changelog landing page sends the manual root
+            // (c/typo3/cms-core/main/en-us) as scope; a slug filter for the
+            // root matches none of these sub-manual slugs and yields zero
+            // results. Route any cms-core scope through the type filter so
+            // the changelog corpus is searchable from the landing page.
+            // Pre-existing user filters on Document Type take precedence.
             // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/89
             // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/128
             if (str_starts_with($scope, 'c/typo3/cms-core/') && empty($filters['manual_type'])) {

--- a/src/Dto/SearchDemand.php
+++ b/src/Dto/SearchDemand.php
@@ -71,9 +71,14 @@ readonly class SearchDemand
         // scope points to given manual version and language
         $scope = trim(htmlspecialchars(strip_tags((string)$request->query->get('scope'))), '/');
         if ($scope) {
-            // special treatment for the Changelog scope because version is "wrong" here
-            // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/89#issuecomment-2696410395
-            if (str_contains($scope, 'c/typo3/cms-core/main/en-us/Changelog') && empty($filters['manual_type'])) {
+            // Special treatment for the Core Changelog: cms-core is only ever indexed
+            // as changelog (see DirectoryFinderService::isNotIgnoredPath), so any cms-core
+            // scope — including the manual root /c/typo3/cms-core/main/en-us/ used by the
+            // search modal on the changelog landing page — must use the type filter,
+            // not the slug filter.
+            // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/89
+            // @see https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/128
+            if (str_starts_with($scope, 'c/typo3/cms-core/') && empty($filters['manual_type'])) {
                 $filters['manual_type'] = ManualType::CoreChangelog->value;
             } else {
                 $filters['manual_slug'] = [$scope];

--- a/tests/Unit/Dto/SearchDemandTest.php
+++ b/tests/Unit/Dto/SearchDemandTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Dto;
 
+use App\Config\ManualType;
 use App\Dto\SearchDemand;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -154,5 +155,71 @@ class SearchDemandTest extends TestCase
         $searchDemand = SearchDemand::createFromRequest($request);
 
         $this->assertSame(3, $searchDemand->getPage());
+    }
+
+    /**
+     * Regression test for issue #128: searching from the Core Changelog
+     * landing page sends scope=/c/typo3/cms-core/main/en-us/ (without the
+     * "Changelog" segment). The detection must still recognise this as a
+     * changelog scope and apply the Core changelog type filter instead of
+     * the (never-matching) slug filter.
+     *
+     * @test
+     */
+    public function createFromRequestUsesChangelogTypeFilterForCmsCoreManualRoot(): void
+    {
+        $request = Request::create(
+            '/search',
+            'GET',
+            ['q' => 'form', 'scope' => '/c/typo3/cms-core/main/en-us/']
+        );
+
+        $searchDemand = SearchDemand::createFromRequest($request);
+
+        $filters = $searchDemand->getFilters();
+        $this->assertSame(ManualType::CoreChangelog->value, $filters['manual_type'] ?? null);
+        $this->assertArrayNotHasKey('manual_slug', $filters);
+    }
+
+    /**
+     * Regression test for PR #108 / issue #89: the original fix for the deep
+     * Changelog scope must keep working.
+     *
+     * @test
+     */
+    public function createFromRequestUsesChangelogTypeFilterForDeepChangelogScope(): void
+    {
+        $request = Request::create(
+            '/search',
+            'GET',
+            ['q' => 'feature', 'scope' => '/c/typo3/cms-core/main/en-us/Changelog/12.4/']
+        );
+
+        $searchDemand = SearchDemand::createFromRequest($request);
+
+        $filters = $searchDemand->getFilters();
+        $this->assertSame(ManualType::CoreChangelog->value, $filters['manual_type'] ?? null);
+        $this->assertArrayNotHasKey('manual_slug', $filters);
+    }
+
+    /**
+     * Other system-extension scopes (e.g. cms-form) must continue to use the
+     * slug-based filter and not be misclassified as Core changelog.
+     *
+     * @test
+     */
+    public function createFromRequestUsesSlugFilterForNonCmsCoreScope(): void
+    {
+        $request = Request::create(
+            '/search',
+            'GET',
+            ['q' => 'form', 'scope' => '/c/typo3/cms-form/main/en-us/']
+        );
+
+        $searchDemand = SearchDemand::createFromRequest($request);
+
+        $filters = $searchDemand->getFilters();
+        $this->assertSame(['c/typo3/cms-form/main/en-us'], $filters['manual_slug'] ?? null);
+        $this->assertArrayNotHasKey('manual_type', $filters);
     }
 }

--- a/tests/Unit/Dto/SearchDemandTest.php
+++ b/tests/Unit/Dto/SearchDemandTest.php
@@ -222,4 +222,49 @@ class SearchDemandTest extends TestCase
         $this->assertSame(['c/typo3/cms-form/main/en-us'], $filters['manual_slug'] ?? null);
         $this->assertArrayNotHasKey('manual_type', $filters);
     }
+
+    /**
+     * Boundary test: the trailing slash in the `c/typo3/cms-core/` prefix
+     * matters. A hypothetical extension named `cms-core-extras` must NOT be
+     * misclassified as Core changelog.
+     *
+     * @test
+     */
+    public function createFromRequestUsesSlugFilterForCmsCorePrefixedExtension(): void
+    {
+        $request = Request::create(
+            '/search',
+            'GET',
+            ['scope' => '/c/typo3/cms-core-extras/main/en-us/']
+        );
+
+        $searchDemand = SearchDemand::createFromRequest($request);
+
+        $filters = $searchDemand->getFilters();
+        $this->assertSame(['c/typo3/cms-core-extras/main/en-us'], $filters['manual_slug'] ?? null);
+        $this->assertArrayNotHasKey('manual_type', $filters);
+    }
+
+    /**
+     * If the user has already chosen a Document Type filter, the changelog
+     * scope detection must NOT override it. The user's explicit choice wins.
+     *
+     * @test
+     */
+    public function createFromRequestPreservesExplicitDocumentTypeFilterForCmsCoreScope(): void
+    {
+        $request = Request::create(
+            '/search',
+            'GET',
+            [
+                'scope' => '/c/typo3/cms-core/main/en-us/',
+                'filters' => ['Document Type' => ['manual' => 'true']],
+            ]
+        );
+
+        $searchDemand = SearchDemand::createFromRequest($request);
+
+        $filters = $searchDemand->getFilters();
+        $this->assertSame(['manual'], $filters['manual_type'] ?? null);
+    }
 }


### PR DESCRIPTION
## Problem

Searching with scope limited to the Core Changelog landing page returns no results. Steps to reproduce (from #128):

1. Open the Changelog section of docs.typo3.org (e.g. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Index.html)
2. Click the search icon, enter a term like `form`, and choose "search in current scope"
3. The result is always *"No search results found"*

## Cause

The Core Changelog is indexed as one `CoreChangelog` sub-manual per version under `c/typo3/cms-core/main/en-us/Changelog/<version>/`. The search modal on the changelog landing page sends the **manual root** (`c/typo3/cms-core/main/en-us`) as the scope. The previous detection only recognised scopes that literally contained the `Changelog` segment, so the landing-page scope fell through to a slug filter that matches none of the per-version sub-manual slugs — hence zero results.

## Fix

Route any `c/typo3/cms-core/` scope through the `CoreChangelog` document-type filter instead of the slug filter. This is the approach proposed and approved in #128. The trailing slash in the prefix guards against false matches like a hypothetical `cms-core-extras`, and a pre-existing explicit *Document Type* filter still takes precedence over the scope-based default.

## Tests

Added regression coverage in `tests/Unit/Dto/SearchDemandTest.php`:

- changelog landing-page scope (`/c/typo3/cms-core/main/en-us/`) → Core changelog type filter (the bug)
- deep changelog scope (`.../Changelog/12.4/`) still works (guards #89 / #108)
- other system extensions (`cms-form`) keep using the slug filter
- `cms-core`-prefixed extension names are not misclassified
- explicit *Document Type* filter is preserved

All unit tests pass locally (`bin/phpunit`: 14 tests, 24 assertions), lint and php-cs-fixer are clean.

Fixes #128