### PR TITLE
[BUGFIX] Recompute "latest" state on import so stale versions drop out

### DIFF
--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -20,6 +20,7 @@ class Manual
         private readonly string $vendor = '',
         private readonly bool $isCore = false,
         private readonly bool $isLastVersions = true, // Does this Manual entry lives in the last 2 major versions? (+main)
+        private readonly array $lastVersions = [], // The manual's current last-versions set (highest per major, +main)
     ) {}
 
     public static function createFromFolder(\SplFileInfo $folder, $changelog = false): Manual
@@ -68,6 +69,7 @@ class Manual
             $vendor,
             $isCore,
             $isLastVersions,
+            $lastVersions,
         );
     }
 
@@ -212,5 +214,16 @@ class Manual
     public function isLastVersions(): bool
     {
         return $this->isLastVersions;
+    }
+
+    /**
+     * The manual's current last-versions set (highest version per major, plus main),
+     * as used to decide 'latest' facet membership.
+     *
+     * @return array<string>
+     */
+    public function getLastVersionsList(): array
+    {
+        return $this->lastVersions;
     }
 }

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -126,6 +126,60 @@ EOD;
     }
 
     /**
+     * Recompute the 'latest' state for every snippet of a manual.
+     *
+     * Two pieces of 'latest' state are written at index time and never revised afterwards, because
+     * old versions are never re-rendered/re-indexed:
+     *   - the 'latest' token in major_versions (the "latest" filter facet, see addOrUpdateDocument);
+     *   - the is_last_versions boolean field (the suggest top_hits sort, #121).
+     * Both are only ever added when a version was the newest, so they keep leaking obsolete
+     * versions once newer ones exist.
+     *
+     * This re-derives both from the manual's *current* last-versions set: a snippet is 'latest' iff
+     * at least one of the versions it appears in is still a last version. Run after importing any
+     * version, so re-rendering the newest version (or main) self-heals stale state.
+     */
+    public function recalculateLatestVersions(Manual $manual): void
+    {
+        $lastVersions = array_values($manual->getLastVersionsList());
+        // If the last-versions set cannot be determined, leave the index untouched.
+        if ($lastVersions === []) {
+            return;
+        }
+
+        $query = new Query([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['term' => ['manual_title.raw' => $manual->getTitle()]],
+                        ['term' => ['manual_type' => $manual->getType()]],
+                        ['term' => ['manual_language' => $manual->getLanguage()]],
+                    ],
+                ],
+            ],
+        ]);
+
+        $scriptCode = <<<'EOD'
+boolean isLatest = false;
+for (def v : ctx._source.manual_version) {
+    if (params.lastVersions.contains(v)) { isLatest = true; break; }
+}
+int idx = ctx._source.major_versions.indexOf('latest');
+if (isLatest) {
+    if (idx < 0) { ctx._source.major_versions.add('latest'); }
+} else if (idx >= 0) {
+    ctx._source.major_versions.remove(idx);
+}
+ctx._source.is_last_versions = isLatest;
+EOD;
+
+        $script = new Script($scriptCode, ['lastVersions' => $lastVersions], AbstractScript::LANG_PAINLESS);
+        $this->elasticIndex->refresh();
+        $this->elasticIndex->updateByQuery($query, $script, ['wait_for_completion' => true, 'conflicts' => 'proceed']);
+        $this->elasticIndex->refresh();
+    }
+
+    /**
      * Removes manual_version from all snippets and if it's the last version, remove the whole snippet
      */
     public function deleteByManual(Manual $manual): void

--- a/src/Service/ImportManualHTMLService.php
+++ b/src/Service/ImportManualHTMLService.php
@@ -29,6 +29,9 @@ class ImportManualHTMLService
     public function importManual(Manual $manual): void
     {
         $this->importSectionsFromManual($manual);
+        // Re-derive 'latest' facet membership for the whole manual from its current
+        // last-versions set, so tags left over from when an old version was newest are dropped.
+        $this->elasticRepository->recalculateLatestVersions($manual);
     }
 
     private function importSectionsFromManual(Manual $manual): void

--- a/tests/Unit/Service/ImportManualHTMLServiceTest.php
+++ b/tests/Unit/Service/ImportManualHTMLServiceTest.php
@@ -142,6 +142,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'is_core' => true,
             'is_last_versions' => true,
         ])->shouldBeCalledTimes(1);
+        $repo->recalculateLatestVersions($manualRevealed)->shouldBeCalledTimes(1);
 
         $subject->importManual($manualRevealed);
     }
@@ -271,6 +272,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'is_core' => true,
             'is_last_versions' => true,
         ])->shouldBeCalledTimes(1);
+        $repo->recalculateLatestVersions($manualRevealed)->shouldBeCalledTimes(1);
 
         $subject->importManual($manualRevealed);
     }


### PR DESCRIPTION
## Problem

The `latest` version filter returns **obsolete** versions of a manual, result links point at outdated documentation, and the autocomplete/suggest sort still prefers stale versions.

Root cause: two pieces of "latest" state are written at index time and never revised, because old versions are never re-rendered/re-indexed:
- the `latest` token in `major_versions` (the "latest" filter facet, `ElasticRepository::addOrUpdateDocument`);
- the `is_last_versions` boolean field (the suggest `top_hits` sort added for #121).

Both are only ever *added* when a version is the newest, so a snippet keeps them once newer versions exist — the state only grows.

## Fix

Derive both from the manual's **current** last-versions set (`Manual::getLastVersionsList()`): a snippet is `latest` iff at least one of the versions it appears in is still a last version. `ElasticRepository::recalculateLatestVersions()` recomputes the facet token **and** the sort field for the whole manual via `updateByQuery` after each import, so re-rendering the newest version (or `main`) self-heals stale state.

## Verification

Reproduced locally with real rendered docs for two manuals — `netresearch/nr-llm` (0.x only) and `georgringer/news` (majors 9/11/12 + main) — imported in release order to recreate the production accumulation, then queried the `latest` filter.

| manual | metric | before | after |
|--------|--------|-------:|------:|
| nr-llm | docs tagged `latest` | 1411/1411 | 1139/1411 |
| nr-llm | result links to outdated versions (under `latest`) | 34 | 2 |
| news | docs tagged `latest` | 1243/1243 | 1126/1243 |
| news | result links to outdated versions (under `latest`) | 29 | 22 |

After the fix a production-like incremental import matches a clean full reindex; the `is_last_versions` field count equals the `latest` facet count (both now derived from the same rule); the obsolete major `9.4` no longer appears in `latest` results (the remaining `news` links point at the current majors `11.4`/`12.3`). Unit suite green (113 tests); `php-cs-fixer` clean.

## Scope

This addresses the stale-`latest` half of #143. Cross-version result de-duplication (same page appearing once per version; links preferring the newest version *within* a fragmented document) is a separate, deeper change and is intentionally **not** part of this PR — see the proposal in #145.

Refs #121, #143.
