### PR TITLE
[TASK] Add integration test suite against real Elasticsearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,9 @@
         "ci:test:unit": [
             "php bin/phpunit -c phpunit.xml.dist"
         ],
+        "ci:test:integration": [
+            "php bin/phpunit -c phpunit.integration.xml"
+        ],
         "fix:php:cs-fixer": [
             "php-cs-fixer fix src -v --using-cache no"
         ]

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Integration tests against a REAL Elasticsearch instance.
+     NOT wired into CI yet — run manually:  composer ci:test:integration
+     (inside DDEV the ELASTICA_HOST is preset to "elasticsearch"). -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         convertDeprecationsToExceptions="false"
+>
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <env name="ELASTICA_INDEX" value="docsearch_test" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Integration">
+            <directory>./tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,8 @@
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>./tests/</directory>
+            <!-- Unit tests only; integration tests need a real ES and run via phpunit.integration.xml -->
+            <directory>./tests/Unit</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Dto/Manual.php
+++ b/src/Dto/Manual.php
@@ -20,6 +20,7 @@ class Manual
         private readonly string $vendor = '',
         private readonly bool $isCore = false,
         private readonly bool $isLastVersions = true, // Does this Manual entry lives in the last 2 major versions? (+main)
+        private readonly array $lastVersions = [], // The manual's current last-versions set (highest per major, +main)
     ) {}
 
     public static function createFromFolder(\SplFileInfo $folder, $changelog = false): Manual
@@ -68,6 +69,7 @@ class Manual
             $vendor,
             $isCore,
             $isLastVersions,
+            $lastVersions,
         );
     }
 
@@ -212,5 +214,16 @@ class Manual
     public function isLastVersions(): bool
     {
         return $this->isLastVersions;
+    }
+
+    /**
+     * The manual's current last-versions set (highest version per major, plus main),
+     * as used to decide 'latest' facet membership.
+     *
+     * @return array<string>
+     */
+    public function getLastVersionsList(): array
+    {
+        return $this->lastVersions;
     }
 }

--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -126,6 +126,60 @@ EOD;
     }
 
     /**
+     * Recompute the 'latest' state for every snippet of a manual.
+     *
+     * Two pieces of 'latest' state are written at index time and never revised afterwards, because
+     * old versions are never re-rendered/re-indexed:
+     *   - the 'latest' token in major_versions (the "latest" filter facet, see addOrUpdateDocument);
+     *   - the is_last_versions boolean field (the suggest top_hits sort, #121).
+     * Both are only ever added when a version was the newest, so they keep leaking obsolete
+     * versions once newer ones exist.
+     *
+     * This re-derives both from the manual's *current* last-versions set: a snippet is 'latest' iff
+     * at least one of the versions it appears in is still a last version. Run after importing any
+     * version, so re-rendering the newest version (or main) self-heals stale state.
+     */
+    public function recalculateLatestVersions(Manual $manual): void
+    {
+        $lastVersions = array_values($manual->getLastVersionsList());
+        // If the last-versions set cannot be determined, leave the index untouched.
+        if ($lastVersions === []) {
+            return;
+        }
+
+        $query = new Query([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['term' => ['manual_title.raw' => $manual->getTitle()]],
+                        ['term' => ['manual_type' => $manual->getType()]],
+                        ['term' => ['manual_language' => $manual->getLanguage()]],
+                    ],
+                ],
+            ],
+        ]);
+
+        $scriptCode = <<<'EOD'
+boolean isLatest = false;
+for (def v : ctx._source.manual_version) {
+    if (params.lastVersions.contains(v)) { isLatest = true; break; }
+}
+int idx = ctx._source.major_versions.indexOf('latest');
+if (isLatest) {
+    if (idx < 0) { ctx._source.major_versions.add('latest'); }
+} else if (idx >= 0) {
+    ctx._source.major_versions.remove(idx);
+}
+ctx._source.is_last_versions = isLatest;
+EOD;
+
+        $script = new Script($scriptCode, ['lastVersions' => $lastVersions], AbstractScript::LANG_PAINLESS);
+        $this->elasticIndex->refresh();
+        $this->elasticIndex->updateByQuery($query, $script, ['wait_for_completion' => true, 'conflicts' => 'proceed']);
+        $this->elasticIndex->refresh();
+    }
+
+    /**
      * Removes manual_version from all snippets and if it's the last version, remove the whole snippet
      */
     public function deleteByManual(Manual $manual): void

--- a/src/Service/ImportManualHTMLService.php
+++ b/src/Service/ImportManualHTMLService.php
@@ -29,6 +29,9 @@ class ImportManualHTMLService
     public function importManual(Manual $manual): void
     {
         $this->importSectionsFromManual($manual);
+        // Re-derive 'latest' facet membership for the whole manual from its current
+        // last-versions set, so tags left over from when an old version was newest are dropped.
+        $this->elasticRepository->recalculateLatestVersions($manual);
     }
 
     private function importSectionsFromManual(Manual $manual): void

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Tests\Integration;
+
+use App\QueryBuilder\ElasticQueryBuilder;
+use App\Repository\ElasticRepository;
+use Elastica\Index;
+use Elastica\Query;
+use Elastica\Query\AbstractQuery;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Base class for integration tests that exercise a real Elasticsearch instance
+ * (queries, aggregations and Painless scripts that unit tests mock away).
+ *
+ * These tests are NOT part of CI yet — run them manually against a running ES:
+ *
+ *     composer ci:test:integration
+ *
+ * Inside DDEV the ELASTICA_HOST is preset to "elasticsearch"; otherwise export it.
+ * Each test runs against an isolated throwaway index ("docsearch_test") built from
+ * the real Elasticorn mapping/settings, so it cannot drift from production.
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    protected const TEST_INDEX = 'docsearch_test';
+
+    protected ElasticRepository $repository;
+
+    protected Index $index;
+
+    protected function setUp(): void
+    {
+        // The repository reads connection settings from $_ENV directly; make sure the
+        // container's real env vars are present there (bootstrap keeps existing ones).
+        foreach (['ELASTICA_HOST', 'ELASTICA_PORT', 'ELASTICA_TRANSPORT', 'ELASTICA_PATH'] as $key) {
+            if (empty($_ENV[$key]) && ($value = getenv($key)) !== false) {
+                $_ENV[$key] = $value;
+            }
+        }
+        $_ENV['ELASTICA_INDEX'] = self::TEST_INDEX;
+
+        $this->repository = new ElasticRepository(new ElasticQueryBuilder());
+        $this->index = $this->repository->getElasticIndex();
+
+        if ($this->index->exists()) {
+            $this->index->delete();
+        }
+        $this->index->create($this->indexDefinition());
+        $this->index->refresh();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->index) && $this->index->exists()) {
+            $this->index->delete();
+        }
+    }
+
+    /**
+     * Build the index from the real Elasticorn config so the test index cannot
+     * drift from the production mapping.
+     *
+     * @return array<string, mixed>
+     */
+    private function indexDefinition(): array
+    {
+        $dir = dirname(__DIR__, 2) . '/config/Elasticorn/docsearch';
+        $settings = Yaml::parseFile($dir . '/IndexConfiguration.yaml');
+        // Single-node test node: no replicas, so the index stays green.
+        $settings['number_of_replicas'] = 0;
+
+        return [
+            'settings' => $settings,
+            'mappings' => ['properties' => Yaml::parseFile($dir . '/Mapping.yaml')],
+        ];
+    }
+
+    /**
+     * A complete snippet with sensible defaults; override per test.
+     *
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    protected function snippet(array $overrides = []): array
+    {
+        return $overrides + [
+            'fragment' => 'section-1',
+            'snippet_title' => 'Title',
+            'snippet_content' => 'Content',
+            'manual_title' => 'acme/demo',
+            'manual_vendor' => 'acme',
+            'manual_extension' => 'demo',
+            'manual_package' => 'acme/demo',
+            'manual_type' => 'c',
+            'manual_version' => 'main',
+            'manual_language' => 'en-us',
+            'manual_slug' => 'p/acme/demo/main/en-us',
+            'manual_keywords' => ['demo'],
+            'relative_url' => 'Index.html',
+            'content_hash' => 'hash-1',
+            'is_core' => false,
+            'is_last_versions' => true,
+        ];
+    }
+
+    /**
+     * _source of every document matching a query (the index is refreshed first).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function sources(AbstractQuery $query): array
+    {
+        $this->index->refresh();
+        $search = (new Query($query))->setSize(100);
+
+        return array_map(
+            static fn ($result) => $result->getSource(),
+            $this->index->search($search)->getResults()
+        );
+    }
+}

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -1,0 +1,19 @@
+# Integration tests
+
+These tests run against a **real Elasticsearch** instance and cover behaviour the
+unit tests mock away — the Painless `latest` recompute, content-hash de-duplication,
+and version-aware queries.
+
+They are **not part of CI yet** and are run manually:
+
+```bash
+composer ci:test:integration
+```
+
+- Inside DDEV the ES host is preset (`ELASTICA_HOST=elasticsearch`); elsewhere export
+  `ELASTICA_HOST` (and `ELASTICA_PORT` if needed) before running.
+- Each test uses an isolated throwaway index (`docsearch_test`), created from the real
+  `config/Elasticorn/docsearch` mapping/settings and dropped again on teardown, so it
+  never touches the `docsearch` index.
+
+The unit suite (`composer ci:test:unit`) covers `tests/Unit` only and needs no ES.

--- a/tests/Integration/Repository/ElasticRepositoryIntegrationTest.php
+++ b/tests/Integration/Repository/ElasticRepositoryIntegrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Tests\Integration\Repository;
+
+use App\Dto\Manual;
+use App\Tests\Integration\IntegrationTestCase;
+use Elastica\Query\Term;
+
+/**
+ * Covers ES behaviour that the mocked unit tests cannot reach:
+ * the Painless "latest" recompute and the content-hash de-duplication.
+ */
+class ElasticRepositoryIntegrationTest extends IntegrationTestCase
+{
+    /**
+     * @test
+     */
+    public function recalculateLatestVersionsDropsStaleLatestAndSyncsSortField(): void
+    {
+        // A snippet that only ever existed in an old version (0.6), tagged "latest"
+        // back when 0.6 was the newest — the stale state that leaks obsolete versions.
+        $this->repository->addOrUpdateDocument($this->snippet([
+            'fragment' => 'old',
+            'content_hash' => 'old-only',
+            'manual_version' => '0.6',
+        ]));
+        // A snippet from the current version.
+        $this->repository->addOrUpdateDocument($this->snippet([
+            'fragment' => 'current',
+            'content_hash' => 'current',
+            'manual_version' => 'main',
+        ]));
+
+        // Before the recompute both carry "latest".
+        self::assertCount(2, $this->sources(new Term(['major_versions' => 'latest'])));
+
+        // Current last-versions set of the manual = only "main".
+        $this->repository->recalculateLatestVersions($this->manual(['main']));
+
+        // After: only the current snippet keeps "latest".
+        self::assertCount(1, $this->sources(new Term(['major_versions' => 'latest'])));
+
+        $old = $this->docByFragment('old');
+        self::assertNotContains('latest', $old['major_versions']);
+        self::assertFalse($old['is_last_versions']);
+
+        $current = $this->docByFragment('current');
+        self::assertContains('latest', $current['major_versions']);
+        self::assertTrue($current['is_last_versions']);
+    }
+
+    /**
+     * @test
+     */
+    public function identicalContentAcrossVersionsIsStoredAsOneDocument(): void
+    {
+        $shared = $this->snippet(['fragment' => 'shared', 'content_hash' => 'shared']);
+
+        $this->repository->addOrUpdateDocument(['manual_version' => '0.6'] + $shared);
+        $this->repository->addOrUpdateDocument(['manual_version' => 'main'] + $shared);
+
+        $docs = $this->sources(new Term(['content_hash' => 'shared']));
+
+        self::assertCount(1, $docs, 'Identical content must dedupe into a single document');
+        self::assertEqualsCanonicalizing(['0.6', 'main'], $docs[0]['manual_version']);
+    }
+
+    /**
+     * @param array<string> $lastVersions
+     */
+    private function manual(array $lastVersions): Manual
+    {
+        return new Manual(
+            absolutePath: '',
+            name: 'demo',
+            type: 'c',
+            version: 'main',
+            language: 'en-us',
+            slug: 'p/acme/demo/main/en-us',
+            keywords: ['demo'],
+            vendor: 'acme',
+            isCore: false,
+            isLastVersions: true,
+            lastVersions: $lastVersions,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function docByFragment(string $fragment): array
+    {
+        $docs = $this->sources(new Term(['fragment' => $fragment]));
+        self::assertCount(1, $docs);
+
+        return $docs[0];
+    }
+}

--- a/tests/Unit/Service/ImportManualHTMLServiceTest.php
+++ b/tests/Unit/Service/ImportManualHTMLServiceTest.php
@@ -142,6 +142,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'is_core' => true,
             'is_last_versions' => true,
         ])->shouldBeCalledTimes(1);
+        $repo->recalculateLatestVersions($manualRevealed)->shouldBeCalledTimes(1);
 
         $subject->importManual($manualRevealed);
     }
@@ -271,6 +272,7 @@ class ImportManualHTMLServiceTest extends TestCase
             'is_core' => true,
             'is_last_versions' => true,
         ])->shouldBeCalledTimes(1);
+        $repo->recalculateLatestVersions($manualRevealed)->shouldBeCalledTimes(1);
 
         $subject->importManual($manualRevealed);
     }


### PR DESCRIPTION
Adds a separate integration test suite that runs against a **real Elasticsearch**, covering the ES round-trip (queries, aggregations, Painless scripts) that the mocked unit tests cannot reach.

> **Stacked on #144.** This branch includes #144's bugfix commit (which adds `recalculateLatestVersions`, one of the behaviours tested here) and will be rebased onto `main` once #144 lands. Please review the `[TASK]` commit; the `[BUGFIX]` commit is #144.

**What's added**
- `tests/Integration/IntegrationTestCase` — creates an isolated throwaway index (`docsearch_test`) from the real `config/Elasticorn` mapping/settings and drops it on teardown, so it never touches `docsearch`.
- Tests: the `latest` recompute (the stale `latest` token **and** the `is_last_versions` sort field are dropped for superseded versions) and content-hash de-duplication (identical content across versions collapses into one document).
- `composer ci:test:integration` with its own `phpunit.integration.xml`.

**Deliberately not wired into CI yet** — run manually. To keep the CI unit run ES-free, the unit suite is scoped to `tests/Unit` (it previously pointed at all of `tests/`).

Locally: integration 2/2 green against ES 7.17, unit 113/113, `php-cs-fixer` clean.

Refs #143. Depends on #144.
