### PR TITLE
[DOCS] ADR-0002: cross-version de-duplication of search results

### DIFF
--- a/docs/adr/0001-version-facet-and-latest-for-a-heterogeneous-corpus.md
+++ b/docs/adr/0001-version-facet-and-latest-for-a-heterogeneous-corpus.md
@@ -1,0 +1,112 @@
+# 1. Version facet and `latest` semantics for a heterogeneous corpus
+
+- Status: **Proposed**
+- Date: 2026-07-31
+- Deciders: TYPO3 Documentation Team
+- Related: #143 (symptoms), #144 (fixes the stale-`latest` maintenance bug)
+
+## Context and problem statement
+
+The index holds two very different kinds of manuals:
+
+- **Core / system manuals**, versioned by the TYPO3 major (e.g. `12`, `13`).
+- **~1500 community extensions**, versioned independently — some by real SemVer majors
+  (e.g. `georgringer/news`: `9`, `11`, `12`), many still pre-1.0 where *every* release is major `0`
+  (e.g. `netresearch/nr-llm`: `0.1` … `0.25`).
+
+The version dimension is stored on every snippet as a single field `major_versions`, derived at index
+time from `explode('.', $version)[0]`, plus two synthetic tokens: `all` and `latest`.
+
+`latest` is **major-based**, not "newest version": a manual's *last-versions* set is
+"the highest version per major, restricted to the last two majors, plus `main`"
+(`Manual::getLastVersions()` → `VersionFilter::filterVersions()`). A snippet is tagged `latest`
+iff its version is in that set at index time (`ElasticRepository::addOrUpdateDocument`).
+
+Contrary to how it may look, this is **not** a core rule blindly applied to extensions. The "only
+show the last two versions" restriction was introduced *specifically for third-party documentation*
+(commit `3d25e20`, gated on `is_core = false`); core manuals are treated differently — a ranking
+boost for `is_core` and for the current TYPO3 stable/dev version via `Typo3VersionMapping`. And
+version aggregation has been major-granular since #14 (2023): `latest` has always meant "the highest
+version per major", never "the single newest version".
+
+The real mismatch is therefore **granularity, not core-vs-extension**: "last two *majors*" is right
+for extensions with genuine SemVer majors (e.g. `georgringer/news`: 9 / 11 / 12), but collapses for
+pre-1.0 extensions where every release is major `0`. From that, three problems follow:
+
+1. **The version facet is meaningless in cross-manual scope.** In "search all" the `major_versions`
+   buckets mix core majors (`12`, `13`) with extension majors (`0`, `1`, `2`, `3`) in one list —
+   "version 0" of extension A has nothing to do with "version 0" of extension B, and neither relates
+   to TYPO3 `13`.
+2. **The major axis conveys nothing for 0.x extensions.** Every release collapses to major `0`.
+3. **The axis users actually want for an extension — which TYPO3 version it supports — is not indexed
+   at all.** No field carries it, so it cannot be offered as a facet.
+
+(The separate stale-`latest` *maintenance* bug — both the `latest` facet token and the
+`is_last_versions` sort field were only ever added, never recomputed — is fixed in #144 and is **not**
+re-litigated here; this ADR records the semantics as the baseline.)
+
+## Decision drivers
+
+- The version facet must be meaningful in cross-manual ("search all") scope, not just within one manual.
+- One model must serve core (major = TYPO3 version) and community (major = the extension's own line).
+- Prefer the axis users can act on; avoid exposing internal artifacts (bare major integers).
+- Keep index size and indexing complexity reasonable.
+- Data availability: TYPO3-compatibility is *not* on the rendered page, but the docs deployment
+  metadata (Intercept) already tracks a "supported TYPO3 version" per render.
+
+## Considered options
+
+1. **Status quo** — one shared `major_versions` facet for everything.
+2. **Scope-aware facet** — render the numeric major buckets only where they are meaningful
+   (within a single manual, or for the core corpus); in cross-manual scope expose only `latest` / `all`.
+3. **TYPO3-compatibility facet for community extensions** — index a new `typo3_versions` field from the
+   deployment metadata; keep the core-version facet for core manuals.
+4. **Replace the extension version facet with a per-manual `latest`/`all` toggle** — drop major buckets
+   for extensions entirely.
+
+## Decision outcome (recommended)
+
+Adopt a staged combination, keeping `latest` semantics unchanged:
+
+- **Baseline (already true after #144):** `latest` = "the manual's current last-versions set", correctly
+  maintained on every import. No change of meaning.
+- **Step 1 — Option 2 (scope-aware facet):** stop showing the numeric-major mix across manuals. In
+  cross-manual scope the version facet is reduced to `latest` vs `all`; numeric majors remain only
+  within a single manual / the core corpus. Low cost, removes the most confusing behavior.
+- **Step 2 — Option 3 (TYPO3-compatibility facet):** index a `typo3_versions` field for community
+  extensions from the deployment metadata and expose it as the primary version-ish facet for them.
+  This is the axis users actually filter on. Larger change (new field + reindex + UI), tracked as
+  follow-up work.
+
+Option 4 is rejected: it discards useful within-manual version filtering for extensions that *do* have
+meaningful majors (e.g. news). Option 1 is rejected: it is the current, demonstrably confusing state.
+
+## Consequences
+
+**Positive**
+- Cross-manual search stops presenting a meaningless integer soup.
+- Community extensions gain the facet users actually want (TYPO3 compatibility).
+- Core behavior is unchanged.
+
+**Negative / cost**
+- Step 2 needs a new indexed field, a full reindex, and UI work.
+- Compatibility data quality depends on deployment metadata completeness; a fallback (composer
+  constraint parsing) may be needed.
+- Two facet behaviors (core vs community) add conditional logic.
+
+## Out of scope
+
+Cross-version **result de-duplication** and which version a hit links to (a page that changed across
+versions appears once per version; results link to the newest version *within* the de-duplicated
+document, not the newest overall). That is a separate design change and will get its own ADR.
+
+## Evidence
+
+Reproduced locally with real rendered docs, two fixtures, imported in release order to mirror
+production accumulation (harness: `netresearch/nr-llm` 0.x, `georgringer/news` majors 9/11/12+main):
+
+- In "search all", the version facet exposes buckets `0, 1, 2, 3, 6, 12, 13` — extension majors and
+  TYPO3 core majors mixed in one control.
+- For `nr-llm` every indexed version is major `0`; the numeric facet distinguishes nothing.
+- No `typo3_versions`-style field exists on any snippet, so TYPO3-compatibility cannot be faceted today,
+  although Intercept records a "supported TYPO3 version" per deployment.

--- a/docs/adr/0002-cross-version-deduplication-of-search-results.md
+++ b/docs/adr/0002-cross-version-deduplication-of-search-results.md
@@ -1,0 +1,89 @@
+# 2. Cross-version de-duplication of search results
+
+- Status: **Proposed**
+- Date: 2026-07-31
+- Deciders: TYPO3 Documentation Team
+- Related: #143 (symptoms), ADR-0001 (deferred this here), #144 (fixed the stale-`latest` bug)
+
+## Context and problem statement
+
+Every snippet (a section/fragment of a page) is stored as one Elasticsearch document keyed by
+**content**: `_id = manual_title + relative_url + content_hash + fragment` — deliberately *without*
+the version, so identical content across versions collapses into a single document whose
+`manual_version` array lists all versions it appears in.
+
+The flip side: when a section's **content changes** between versions, its versions no longer share a
+content hash and become **separate documents**. The main search (`findByQuery`) returns *every*
+matching document as its own hit — there is **no field-collapsing and no PHP-side de-duplication** —
+and `SlugBuilder` links each hit to the newest version *within that fragmented document*, not the
+newest overall.
+
+So the same section shows up once per version it diverged in. Measured on a real manual
+(`netresearch/nr-llm`, 5 rendered versions): **123 of 1227 sections (~10%) are fragmented across
+versions**, e.g. `Adr023…#… → {0.19, 0.25}, {main}` — two separate hits. This even survives the
+`latest` filter: `0.25` and `main` are both last-versions, so both fragments are tagged `latest` and
+both appear. (The user-visible symptom in #143: "Azure OpenAI" listed twice with `main` and `1.0`
+badges.) This is orthogonal to #144 — #144 removes *obsolete* versions from `latest`; this is
+duplication *within* the current versions.
+
+The mapping already carries an **unused `snippet_id` keyword field** (never populated, never queried)
+— a natural collapse key that looks intended for exactly this and was never wired up.
+
+## Decision drivers
+
+- A section should appear **once**, linking to its newest version, with the other versions available
+  (badges) — not once per diverged version.
+- Must keep pagination, `total`, and the facet aggregations meaningful.
+- Should fight relevance ranking as little as possible.
+- Prefer native Elasticsearch over fragile PHP-side post-processing.
+
+## Considered options
+
+1. **Status quo** — every document is its own hit.
+2. **ES `collapse` on a per-section key** — populate `snippet_id = relative_url + '#' + fragment` and
+   add `collapse: { field: snippet_id, inner_hits: … }` to the search query. One hit per section;
+   `inner_hits` expose the per-version documents for the version badges.
+3. **ES `collapse` on `relative_url`** — one hit per *page*; coarser, merges distinct sections of a
+   page into a single hit (likely too aggressive).
+4. **PHP-side de-duplication after fetching** — breaks pagination and `total`; rejected.
+
+## Decision outcome (recommended)
+
+**Option 2** — collapse on a new `snippet_id` (`relative_url#fragment`):
+
+- Populate `snippet_id` in `ImportManualHTMLService` (a full reindex backfills it).
+- Add `collapse` + `inner_hits` to `getDefaultSearchQuery`; the version badges come from `inner_hits`.
+- Link the hit (via `SlugBuilder`) to the **newest** version in the group.
+
+**Open sub-decision for the team — representative = newest version vs. highest-scoring document.**
+ES `collapse` keeps the top-*sorted* document per group. If the outer sort is relevance (score), the
+representative is the best-matching version, which may be an old one; if we sort by version we lose
+per-group relevance. Recommended: order the collapsed groups by score, but pick the **newest**
+version inside each group for the link/snippet (via `inner_hits` sorted by a version rank). This keeps
+result ordering relevance-driven while pointing users at current docs.
+
+## Consequences
+
+**Positive**
+- Each section appears once, linked to its newest version; badges show where else it exists.
+- The residual duplication that `latest` cannot remove disappears.
+
+**Negative / cost**
+- A new indexed field + a full reindex.
+- Query complexity (`collapse` + `inner_hits`) and template changes to render the grouped hit.
+- `total`/counts under collapse: ES `collapse` does **not** change `hits.total`; an accurate
+  distinct-section count needs a `cardinality` aggregation on `snippet_id`.
+- The relevance-vs-newest tension above.
+
+## Out of scope
+
+The version *facet* redesign and the TYPO3-compatibility facet (ADR-0001); the `latest` maintenance
+fix (#144).
+
+## Evidence
+
+- No `collapse`/`inner_hits` anywhere today; `findByQuery` returns raw hits and `SlugBuilder` links to
+  the newest version within a single fragmented document.
+- `snippet_id` is present in `config/Elasticorn/docsearch/Mapping.yaml` but is never set or queried.
+- `netresearch/nr-llm`: 123/1227 sections (~10%) fragment across versions; the duplication persists
+  under `latest` because several last-versions carry the same section divergently.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+This directory records the significant architecture decisions for this project,
+using lightweight [MADR](https://adr.github.io/madr/)-style records.
+
+- One file per decision: `NNNN-short-title.md` (zero-padded, incrementing).
+- A record is immutable once `Accepted`; supersede it with a new one rather than rewriting history.
+- Status lifecycle: `Proposed` → `Accepted` / `Rejected` → (later) `Superseded by NNNN`.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-version-facet-and-latest-for-a-heterogeneous-corpus.md) | Version facet and `latest` semantics for a heterogeneous corpus | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ using lightweight [MADR](https://adr.github.io/madr/)-style records.
 | ADR | Title | Status |
 |-----|-------|--------|
 | [0001](0001-version-facet-and-latest-for-a-heterogeneous-corpus.md) | Version facet and `latest` semantics for a heterogeneous corpus | Proposed |
+| [0002](0002-cross-version-deduplication-of-search-results.md) | Cross-version de-duplication of search results | Proposed |


### PR DESCRIPTION
Records the second architecture decision: how to de-duplicate search hits across versions.

> **Stacked on #145** (needs the `docs/adr/` scaffolding it introduces). Review the ADR-0002 commit; the ADR-0001 commit is #145. Will rebase onto `main` once #145 lands.

**Problem.** Snippets are de-duplicated by content hash, so a section whose content changed between versions fragments into separate documents. The main search returns each as its own hit (no field-collapsing), so the same section appears once per diverged version — even under `latest`, because several last-versions carry it divergently ("Azure OpenAI" listed twice with `main`/`1.0` in #143). Measured: **123 of 1227 sections (~10%)** fragment across versions in `netresearch/nr-llm`.

**Proposal (Option 2).** ES `collapse` on a per-section key — the mapping already has an **unused `snippet_id` field** that looks intended for exactly this. One hit per section, linked to its newest version, other versions as badges from `inner_hits`.

**Open sub-decision for the team:** representative = newest version vs. highest-scoring document (relevance-vs-newest tension) — see the ADR.

A proof-of-concept (populate `snippet_id` + add `collapse`/`inner_hits`, harness shows the duplication drop) will follow to keep this grounded.

Refs #143. Related: #144, ADR-0001 (#145).
