### PR TITLE
[BUGFIX] Fix search results UX: query, scope and facet label

### DIFF
--- a/src/Config/Labels.php
+++ b/src/Config/Labels.php
@@ -14,8 +14,8 @@ class Labels
         'manual_type' => 'Document Type',
         'major_versions' => 'Major Version',
         'manual_language' => 'Language',
-        'option' => 'Option',
-        'optionaggs' => 'Option',
+        'option' => 'Content type',
+        'optionaggs' => 'Content type',
     ];
 
     public static function getLabelForEsColumn(string $filter, string $default = ''): string

--- a/templates/partial/base/page_header.html.twig
+++ b/templates/partial/base/page_header.html.twig
@@ -17,7 +17,7 @@
                                 <select class="form-select search__scope" id="searchscope" name="scope">
                                     <option value="">Search all</option>
                                 </select>
-                                <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="{{ q is defined ? q : '' }}">
                                 <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -65,6 +65,19 @@
     <script>
         var searchCount = {{ results.totalResults }};
     </script>
+    {% set scopePackage = filters.package is defined ? filters.package : (filters.vendor is defined ? filters.vendor : '') %}
+    {% if searchScope is not empty or scopePackage %}
+        <p class="mb-3">
+            <span class="text-muted">Scope:</span>
+            {% if searchScope is not empty %}
+                <span class="badge bg-info text-dark">{{ searchScope }}</span>
+            {% endif %}
+            {% if scopePackage %}
+                <span class="badge bg-info text-dark">{{ filters.package is defined ? 'manual' : 'vendor' }}: {{ scopePackage }}</span>
+            {% endif %}
+            <a class="ms-2 small" href="{{ path('searchresult', {'q': q}) }}">Search all &times;</a>
+        </p>
+    {% endif %}
     {% if results.totalResults > 0 %}
         <h4>Showing hits <strong>{{ results.startingAtItem }} </strong>to <strong>{{ results.endingAtItem }}</strong> of <strong>{{ results.totalResults }}</strong></h4>
         <div class="row">


### PR DESCRIPTION
Fixes three reported defects on the search **results** page (server-side templates; independent of the theme-JS fix in TYPO3-Documentation/render-guides#1361).

1. **Query not echoed** — the header search box `value` was hard-coded empty, so after searching the box looked blank. Now pre-filled with the active query. *(On the live site this is masked by the JS search overlay; it shows on the raw template.)*
2. **Invisible scope** — a search scoped via `filters[package]` looked identical to a global search. Now a **`Scope: manual: <package>`** badge with a **"Search all"** reset.
3. **"Option / Option" facet** — heading and value were both "Option". Heading relabelled to **"Content type"**.

## Before / After

Same URL, same data — only the code differs (screenshots from a local instance, the only place the fix currently runs):

![before/after](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/before-after.png)

**Current live state** (this bug, on production — not yet fixed): <https://docs.typo3.org/search/search?q=openai&filters%5Bpackage%5D=netresearch/nr-llm>

Unit suite green (113); `php-cs-fixer` clean. Refs #143.
