### PR TITLE
[BUGFIX] Relabel the confval facet heading to "Content type"

### DIFF
--- a/src/Config/Labels.php
+++ b/src/Config/Labels.php
@@ -14,8 +14,8 @@ class Labels
         'manual_type' => 'Document Type',
         'major_versions' => 'Major Version',
         'manual_language' => 'Language',
-        'option' => 'Option',
-        'optionaggs' => 'Option',
+        'option' => 'Content type',
+        'optionaggs' => 'Content type',
     ];
 
     public static function getLabelForEsColumn(string $filter, string $default = ''): string


### PR DESCRIPTION
Relabels the configuration-option facet heading from `Option` to `Content type`.

**Why:** the facet rendered as **"Option / Option (9)"** — heading and value were both "Option". The value comes from `data-search-facet` (render-guides sets **"Option"** as the default for a `confval`, e.g. `organization_id`). The facet also holds other content types across manuals (`Console Command`, `ViewHelper Argument`, `file`), so **"Content type"** fits.

| Before (`main`) | After (this PR) |
|:--:|:--:|
| ![before](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/facet-before.png) | ![after](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/facet-after.png) |

Split out of #149. Refs #143.
