### PR TITLE
[TASK] Pre-fill the results-page search box with the active query

### DIFF
--- a/templates/partial/base/page_header.html.twig
+++ b/templates/partial/base/page_header.html.twig
@@ -17,7 +17,7 @@
                                 <select class="form-select search__scope" id="searchscope" name="scope">
                                     <option value="">Search all</option>
                                 </select>
-                                <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="">
+                                <input autocomplete="off" class="form-control shadow-none" id="globalsearchinput" name="q" placeholder="TYPO3 documentation..." type="text" value="{{ q is defined ? q : '' }}">
                                 <button class="btn btn-light" type="submit"><i class="fa fa-search"></i>&nbsp;<span class="d-none d-md-inline">Search</span></button>
                             </div>
                         </form>


### PR DESCRIPTION
Pre-fills the header search box on the results page with the active query (it was hard-coded `value=""`).

**Scope — honest framing:** on the live site the visible search field is a **React component** (`SearchModal`) that manages the query itself; the static `#globalsearchinput` this touches stays empty and hidden behind it. So this is a **progressive-enhancement / no-JS fallback** fix, **not** a production-visible bug.

**No caching concern:** `page_header` renders only on this app's own pages (`/`, `/search`), not the cached static manual pages; `/search` is served `Cache-Control: no-cache, private`; there is no fragment/ESI caching of the header.

| Before (`main`) | After (this PR) |
|:--:|:--:|
| ![before](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/box-before.png) | ![after](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/box-after.png) |

Split out of #149. Refs #143.
