### PR TITLE
[FEATURE] Show the active package/vendor scope on the results page

### DIFF
--- a/templates/partial/aggregations.html.twig
+++ b/templates/partial/aggregations.html.twig
@@ -12,6 +12,21 @@
             </h2>
         </div>
         <div class="card-body">
+            {% if scopeValue is defined and scopeValue %}
+                {# Active search scope shown as a checked checkbox, consistent with the other
+                   facets; unchecking it broadens the search to all manuals. #}
+                <div class="aggregation">
+                    <div class="aggregation-title">
+                        <span class="fs-4 fw-bold aggregation-title-text">{{ scopeKey == 'package' ? 'Manual' : 'Vendor' }}</span>
+                    </div>
+                    <div class="aggregation-body">
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="scope-{{ scopeKey }}" name="filters[{{ scopeKey }}]" value="{{ scopeValue }}" checked onchange="this.form.submit()">
+                            <label class="form-check-label" for="scope-{{ scopeKey }}">{{ scopeValue }}</label>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
             {% for title, buckets in aggregations %}
                 <div class="aggregation">
                     <div class="aggregation-title" id="aggregation-title-{{ loop.index }}">

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -101,7 +101,13 @@
                 <div class="wy-menuXX wy-menu-verticalXX" data-spy="affix" role="navigation" aria-label="main navigation">
                     <form action="{{ path('searchresult') }}" method="get" class="form">
                         <input type="hidden" name="q" value="{{ (q is defined) ? q : '' }}">
-                        {% include 'partial/aggregations.html.twig' with {'aggregations': results.aggs, 'query': q, 'searchFilter': searchFilter} only %}
+                        {% include 'partial/aggregations.html.twig' with {
+                            'aggregations': results.aggs,
+                            'query': q,
+                            'searchFilter': searchFilter,
+                            'scopeKey': (filters.package is defined ? 'package' : (filters.vendor is defined ? 'vendor' : '')),
+                            'scopeValue': (filters.package is defined ? filters.package : (filters.vendor is defined ? filters.vendor : ''))
+                        } only %}
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Shows the active search scope as a **checked "Manual" / "Vendor" checkbox** at the top of the facet sidebar, consistent with the other filters. Unchecking it broadens to all manuals, and it carries the scope through facet toggles (which previously dropped it).

**Backed by issue #47:** @brotkrueml asked there for a visible scope context (*"like 'Searching in News'"* + *"a link to the overall search"*). PR #75 never added it. This is the **checkbox variant** (per review) — the scope rendered like the other facets rather than a separate badge.

| Before (`main`) | After (this PR) |
|:--:|:--:|
| ![before](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/scope-before.png) | ![after](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/scope-after.png) |

(The React search surfaces scope only for the `scope=` param, not `filters[package]`.) Split out of #149. Refs #143, #47.
