### PR TITLE
[TASK] Revisit hiding the facet sidebar for scoped searches

### DIFF
--- a/src/Repository/ElasticRepository.php
+++ b/src/Repository/ElasticRepository.php
@@ -683,6 +683,13 @@ EOD;
                         'filter' => ['terms' => [$key => $value]],
                         'weight' => 10,
                     ];
+                } elseif ($key === 'manual_slug') {
+                    // The scope (manual_slug) must constrain the aggregations too, so apply it to
+                    // the main query rather than the post_filter. As a post_filter (like the other
+                    // facets) the facet counts would ignore the scope and span all manuals, which
+                    // is why the sidebar used to be hidden for scoped searches (issue #47 /
+                    // commit 51eabd4).
+                    $query['query']['function_score']['query']['bool']['must'][] = ['terms' => [$key => $value]];
                 } else {
                     $query['post_filter']['bool']['must'][] = ['terms' => [$key => $value]];
                 }

--- a/templates/search/search.html.twig
+++ b/templates/search/search.html.twig
@@ -68,7 +68,7 @@
     {% if results.totalResults > 0 %}
         <h4>Showing hits <strong>{{ results.startingAtItem }} </strong>to <strong>{{ results.endingAtItem }}</strong> of <strong>{{ results.totalResults }}</strong></h4>
         <div class="row">
-            <div class="{{ (searchScope is empty) ? 'col-md-8 col-lg-9 order-2 order-md-1 mb-4' : 'mb-4' }}">
+            <div class="col-md-8 col-lg-9 order-2 order-md-1 mb-4">
                 <ul class="list-group">
                     {% for hit in results.results %}
                         <li class="list-group-item list-group-item-action hit">
@@ -96,16 +96,15 @@
                     {% endfor %}
                 </ul>
             </div>
-            {% if searchScope is empty %}
             <div class="col-md-4 col-lg-3 order-1 order-md-2 mb-4">
                 <div class="wy-menuXX wy-menu-verticalXX" data-spy="affix" role="navigation" aria-label="main navigation">
                     <form action="{{ path('searchresult') }}" method="get" class="form">
                         <input type="hidden" name="q" value="{{ (q is defined) ? q : '' }}">
+                        {% if searchScope is not empty %}<input type="hidden" name="scope" value="{{ searchScope|striptags }}">{% endif %}
                         {% include 'partial/aggregations.html.twig' with {'aggregations': results.aggs, 'query': q, 'searchFilter': searchFilter} only %}
                     </form>
                 </div>
             </div>
-            {% endif %}
         </div>
     {% else %}
         <h4>No search results found for: {{ q }}</h4>


### PR DESCRIPTION
> Draft — revisits an **intentional** decision and fixes its underlying reason.

**Why the facets were hidden:** commit 51eabd4 (PR #75, issue #47) hid the sidebar for scoped searches because the scope is applied as a **`post_filter`** (`manual_slug`), which does **not** constrain the aggregations — so facet counts would span **all** manuals and mislead.

**What this PR does:** render the sidebar for scoped searches (preserving the scope in the facet form) **and** apply the scope to the main query (`must`, not `post_filter`) so the **aggregations are scoped too**. Verified: version facet reports **61** (scoped) instead of **95** (global).

| Before (`main`) — scoped, no filters | After (this PR) — filters, scoped counts |
|:--:|:--:|
| ![before](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/scoped-before.png) | ![after](https://raw.githubusercontent.com/CybotTM/t3docs-search-indexer/media/pr149-screenshots/.screenshots/scoped-after.png) |

Refs #143, #47. Commit that introduced the hiding: 51eabd4.
