### PR TITLE
[BUGFIX] Stop loading the Universe bundle as a classic script

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,9 +19,7 @@ parameters:
                 - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.38.0/css/theme.css'
             footer:
         js:
-            header:
-                - 'https://cdn.typo3.com/typo3infrastructure/universe/dist/webcomponents-loader.js'
-                - 'https://cdn.typo3.com/typo3infrastructure/universe/dist/typo3-universe.js'
+            header: []
             footer:
                 - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.38.0/js/popper.min.js'
                 - 'https://cdn.typo3.com/typo3documentation/theme/typo3-docs-theme/0.38.0/js/bootstrap.min.js'


### PR DESCRIPTION
On the search pages the console throws:

```
Uncaught SyntaxError: Unexpected token 'export'
```

The TYPO3 Universe bundle (`typo3-universe.js`) is an **ES module**, but `config/services.yaml` listed it under `assets.js.header`, which `render_assets()` renders as a **classic** `<script type="text/javascript">`. Loading an ES module as a classic script throws the `export` SyntaxError.

The bundle is already loaded correctly as `type="module"` in `layout/base.html.twig` (the "UNIVERSE BAR" block), so the `services.yaml` entry is both redundant and broken. Remove it (with the duplicate `webcomponents-loader.js`).

**Verified** (headless Chromium against the search page): the classic `<script … type="text/javascript">typo3-universe.js</script>` tag is gone (only the `type="module"` one remains), and the `Unexpected token 'export'` page error no longer fires.

Refs #143.
